### PR TITLE
Update the "Get Involved" section

### DIFF
--- a/source/index.html.haml
+++ b/source/index.html.haml
@@ -260,4 +260,4 @@
           %a{:href => "https://github.com/flatpak/flatpak"} Github
           and issues are tracked on 
           = succeed "." do
-            %a{:href => "https://bugs.freedesktop.org/enter_bug.cgi?product=xdg-app"} Freedesktop Bugzilla
+            %a{:href => "https://github.com/flatpak/flatpak/issues"} Github Issues

--- a/source/index.html.haml
+++ b/source/index.html.haml
@@ -257,7 +257,7 @@
           or 
           %em #flatpak
           IRC channel on Freenode. Code can be found on
-          %a{:href => "https://github.com/alexlarsson/xdg-app"} Github
+          %a{:href => "https://github.com/flatpak/flatpak"} Github
           and issues are tracked on 
           = succeed "." do
             %a{:href => "https://bugs.freedesktop.org/enter_bug.cgi?product=xdg-app"} Freedesktop Bugzilla

--- a/source/index.html.haml
+++ b/source/index.html.haml
@@ -255,7 +255,7 @@
           project. To get in touch, use the 
           %a{:href => "http://lists.freedesktop.org/mailman/listinfo/xdg-app"} xdg-app mailing list
           or 
-          %em flatpak
+          %em #flatpak
           IRC channel on Freenode. Code can be found on
           %a{:href => "https://github.com/alexlarsson/xdg-app"} Github
           and issues are tracked on 


### PR DESCRIPTION
* Rename the IRC channel from flatpak to #flatpak
* update the github repo from /alexlarrson/xdg-app to /flatpak/flatpak
* update the link for the bugtracker to show the github issues page instead of the fd.o bugtracker