### PR TITLE
Update Archlinux section in Getting Flatpak

### DIFF
--- a/source/getting.html.haml.markdown
+++ b/source/getting.html.haml.markdown
@@ -35,9 +35,9 @@
 
   ### Arch
 
-  A `flatpak` package is available in the Archlinux official repositories.
+  A `flatpak` package is available in the official repositories.
   
-  Also `flatpak-git` is available in the AUR if you want to try out the latest development snapshot.
+  Also `flatpak-git` is available in the AUR for the latest development snapshot.
 
   ### Mageia
 

--- a/source/getting.html.haml.markdown
+++ b/source/getting.html.haml.markdown
@@ -35,7 +35,9 @@
 
   ### Arch
 
-  A `flatpak` package is available in the AUR.
+  A `flatpak` package is available in the Archlinux official repositories.
+  
+  Also `flatpak-git` is available in the AUR if you want to try out the latest development snapshot.
 
   ### Mageia
 


### PR DESCRIPTION
Update Archlinux section:
* `flatpak` is now in the official repositories
* Mention `flatpak-git` which is available in the AUR (for automatically installing latest development snapshot from git)