### PR TITLE
Update command line examples according to new standards and fix typos

### DIFF
--- a/source/developer.html.haml.markdown
+++ b/source/developer.html.haml.markdown
@@ -117,17 +117,17 @@
   As described above, an SDK is a special type of runtime that is used to build applcations. Typically, an SDK is paired with a runtime that will be used by the app at runtime. The GNOME 3.20 SDK is used to build applications that use the GNOME 3.20 runtime, for example. The rest of this guide uses this SDK and runtime for its examples. To do this, download the repository GPG key and then add the repository that contains the runtime and SDK:
 
       $ wget https://sdk.gnome.org/keys/gnome-sdk.gpg
-      $ flatpak remote-add --user --gpg-import=gnome-sdk.gpg gnome https://sdk.gnome.org/repo/
+      $ flatpak remote-add --gpg-import=gnome-sdk.gpg gnome https://sdk.gnome.org/repo/
 
   You can now download and install the runtime and SDK. (If you have already completed the tutorial on the Flatpak homepage, you will already have the runtime installed)
 
-      $ flatpak --user install gnome org.gnome.Platform 3.20
-      $ flatpak --user install gnome org.gnome.Sdk 3.20
+      $ flatpak install gnome org.gnome.Platform 3.20
+      $ flatpak install gnome org.gnome.Sdk 3.20
 
   This might be a good time to try installing an application and having a look 'under the hood'. To do this, you need to add a repository that contains applications. In this case we are going to use the gnome-apps repository and install gedit:
 
-      $ flatpak --user remote-add --gpg-import=gnome-sdk.gpg gnome-apps https://sdk.gnome.org/repo-apps/
-      $ flatpak --user install gnome-apps org.gnome.gedit stable
+      $ flatpak remote-add --gpg-import=gnome-sdk.gpg gnome-apps https://sdk.gnome.org/repo-apps/
+      $ flatpak install gnome-apps org.gnome.gedit stable
 
   You can now use the following command to get a shell in the 'devel sandbox':
 
@@ -185,8 +185,8 @@
   At this point you have successfully built a flatpak and prepared it to be run. To test the app, you need to export the Dictionary to a repository, add that repository and then install and run the app:
 
       $ flatpak build-export repo dictionary
-      $ flatpak --user remote-add --no-gpg-verify --if-not-exists tutorial-repo repo
-      $ flatpak --user install tutorial-repo org.gnome.Dictionary
+      $ flatpak remote-add --no-gpg-verify --if-not-exists tutorial-repo repo
+      $ flatpak install tutorial-repo org.gnome.Dictionary
       $ flatpak run org.gnome.Dictionary
 
   This exports the app, creates a repository called tutorial-repo, installs the Dictionary application and runs it.
@@ -261,11 +261,11 @@
 
   It is now possible to update the installed version of the Dictionary application with the new version that was built and exported by flatpak-builder:
 
-      $ flatpak --user update org.gnome.Dictionary
+      $ flatpak update org.gnome.Dictionary
 
   To check that the application has been successfully updated, you can compare the sha256 commit of the installed app with the commit ID that was printed by flatpak-builder:
 
-      $ flatpak --user info org.gnome.Dictionary
+      $ flatpak info org.gnome.Dictionary
 
   And finally, you can run the new version of the Dictionary app:
 
@@ -316,7 +316,7 @@
 
   flatpak run can also be used to permanently override an application's permissions:
 
-      $ flatpak --user override --filesystem=home org.gnome.Dictionary
+      $ flatpak override --filesystem=home org.gnome.Dictionary
       $ flatpak run --command=ls org.gnome.Dictionary ~/
 
   It is also possible to remove permissions using the same method. You can use the following command to see what happens when access to the filesystem is removed, for example:
@@ -394,7 +394,7 @@
 
   As already described, flatpak uses the AppData standard to store user visible information about applications. This information needs to be accessible to clients in order to be displayed in app stores. To do this, build-update-repo scans all the branches in the repository for AppData data, which is collected and committed into a repository-wide AppStream branch. flatpak then keeps a local copy of this branch for each remote, which can be manually updated using the update command. For example:
 
-      $ flatpak --user update --appstream nightly
+      $ flatpak update --appstream nightly
 
   ### Hosting a repository
 

--- a/source/developer.html.haml.markdown
+++ b/source/developer.html.haml.markdown
@@ -60,11 +60,11 @@
 
   ### Sandboxes<a id="sandboxes"></a>
 
-  With Flatpak, each app is built and run in an isolated environment. By default, the application can only 'see' itself and its runtime. Access to user files, network, graphics sockets, subsystems on the bus and devices all has to be explicitly granted. (As will be described later, Flatpak provides several ways to do this.) Access to other things, such as other processes, is (deliberately) not possible.
+  With Flatpak, each app is built and run in an isolated environment. By default, the application can only 'see' itself and its runtime. Access to user files, network, graphics sockets, subsystems on the bus and devices have to be explicitly granted. (As will be described later, Flatpak provides several ways to do this.) Access to other things, such as other processes, is (deliberately) not possible.
 
   ## The flatpak Command
 
-  `flatpak` is the tool that is used install, remove and update runtimes and applications. It can also be used to view what is currently installed, and has commands for building and distributing application bundles. `flatpak --help` provides a full list of available commands.
+  `flatpak` is the tool that is used to install, remove and update runtimes and applications. It can also be used to view what is currently installed, and has commands for building and distributing application bundles. `flatpak --help` provides a full list of available commands.
 
   ## Anatomy of a Flatpak App
 
@@ -119,7 +119,7 @@
       $ wget https://sdk.gnome.org/keys/gnome-sdk.gpg
       $ flatpak remote-add --user --gpg-import=gnome-sdk.gpg gnome https://sdk.gnome.org/repo/
 
-  You can now download and install the runtime and SDK. (If you have already completed the tutorial on the Flatpak homepage, you will already have the runtime installed.)
+  You can now download and install the runtime and SDK. (If you have already completed the tutorial on the Flatpak homepage, you will already have the runtime installed)
 
       $ flatpak --user install gnome org.gnome.Platform 3.20
       $ flatpak --user install gnome org.gnome.Sdk 3.20
@@ -374,8 +374,7 @@
 
   ## Distributing Applications
 
-  As has already been seen, flatpak installs runtimes and apps from repositories. To do this, it uses [OSTree](https://ostree.readthedocs.io/en/latest/)
-  . This is similar to Git, but has been designed to handle trees of large binaries. Like Git, it has the concept of repositories and commits. Applications are stored as branches.
+  As has already been seen, flatpak installs runtimes and apps from repositories. To do this, it uses [OSTree](https://ostree.readthedocs.io/en/latest/). This is similar to Git, but has been designed to handle trees of large binaries. Like Git, it has the concept of repositories and commits. Applications are stored as branches.
 
   To distribute an application, it must be exported to a repository. This is done using the build-export command:
 
@@ -393,7 +392,7 @@
 
   ### AppData
 
-  As already described, flatpak uses the AppData standard to store user visible information about applications. This information needs to be accessible to clients in order to be displayed in app stores. To do this, build-update-repo scans all the branches in the repository for AppData data, which is collected and committed into a repository-wide AppStream branch. flatpak then keeps a local copy of this branch for each remote, which can manually updated using the update command. For example:
+  As already described, flatpak uses the AppData standard to store user visible information about applications. This information needs to be accessible to clients in order to be displayed in app stores. To do this, build-update-repo scans all the branches in the repository for AppData data, which is collected and committed into a repository-wide AppStream branch. flatpak then keeps a local copy of this branch for each remote, which can be manually updated using the update command. For example:
 
       $ flatpak --user update --appstream nightly
 

--- a/source/developer.html.haml.markdown
+++ b/source/developer.html.haml.markdown
@@ -231,7 +231,7 @@
 
   flatpak-builder performs a cleanup phase after the build, which can be used to remove headers and development docs, among other things. Two properties in the manifest file can be used for this. First, a list of filename patterns can be included:
 
-      cleanup": [ "/include", "/bin/foo-*", "*.a" ]
+      "cleanup": [ "/include", "/bin/foo-*", "*.a" ]
 
   The second cleanup property is a list of commands that are run during the cleanup phase:
 

--- a/source/developer.html.haml.markdown
+++ b/source/developer.html.haml.markdown
@@ -126,7 +126,7 @@
 
   This might be a good time to try installing an application and having a look 'under the hood'. To do this, you need to add a repository that contains applications. In this case we are going to use the gnome-apps repository and install gedit:
 
-      $ flatpak --user remote-add --gpg-key=gnome-sdk.gpg gnome-apps https://sdk.gnome.org/repo-apps/
+      $ flatpak --user remote-add --gpg-import=gnome-sdk.gpg gnome-apps https://sdk.gnome.org/repo-apps/
       $ flatpak --user install gnome-apps org.gnome.gedit stable
 
   You can now use the following command to get a shell in the 'devel sandbox':

--- a/source/index.html.haml
+++ b/source/index.html.haml
@@ -34,13 +34,13 @@
     .row
       .col-lg-4.col-sm-6
         %h3.text-center Runtimes
-        %p Runtimes contain the dependencies that are used by apps. They are always the same, whatever Linux distribution is being used. They mean that apps no longer have to be updated to keep pace with distribution changes.
+        %p Runtimes contain the dependencies that are used by apps. They are always the same, whatever Linux distribution is being used. It means that apps no longer have to be updated to keep pace with distribution changes.
       .col-lg-4.col-sm-6
         %h3.text-center Bundled Libraries
-        %p Dependencies that aren't in a runtime can be bundled as a part of the app. This makes it possible to use dependencies that aren't in a distribution, and to use a different version of a dependency than the one that's in a distribution.
+        %p Dependencies that aren't in a runtime can be bundled as part of the app. This makes it possible to use dependencies that aren't in a distribution, and to use a different version of a dependency than the one that's in a distribution.
       .col-lg-4.col-lg-offset-0.col-sm-6.col-sm-offset-3
         %h3.text-center Sandboxes
-        %p Flatpak isolates apps from the host OS as well as from other applications. This provides security for users and a predictable environment for developers. (Some of these features are work in progress.)
+        %p Flatpak isolates apps from the host OS as well as from other applications. This provides security for users and a predictable environment for developers. (Some of these features are work in progress)
         
         
 %section#users

--- a/source/index.html.haml
+++ b/source/index.html.haml
@@ -101,27 +101,27 @@
         %pre
           :preserve
             $ wget https://sdk.gnome.org/keys/gnome-sdk.gpg
-            $ flatpak remote-add --user --gpg-import=gnome-sdk.gpg gnome https://sdk.gnome.org/repo/
-            $ flatpak --user remote-add --gpg-import=gnome-sdk.gpg gnome-apps https://sdk.gnome.org/repo-apps/
+            $ flatpak remote-add --gpg-import=gnome-sdk.gpg gnome https://sdk.gnome.org/repo/
+            $ flatpak remote-add --gpg-import=gnome-sdk.gpg gnome-apps https://sdk.gnome.org/repo-apps/
         %h3 3. Install a runtime
         %p
           The runtime provides the dependencies needed by the apps in the GNOME
           repository.
         %pre
           :preserve
-            $ flatpak --user install gnome org.gnome.Platform 3.20
+            $ flatpak install gnome org.gnome.Platform 3.20
         %p Once this is complete, you're all set to install some apps!
         %h3 4. View, install and run apps
         %p
           To view which apps are availalbe in the gnome-apps repository, just run:
         %pre
           :preserve
-            $ flatpak --user remote-ls gnome-apps --app
+            $ flatpak remote-ls gnome-apps --app
         %p
           To download and install an app, like gedit, run:
         %pre
           :preserve
-            $ flatpak --user install gnome-apps org.gnome.gedit stable
+            $ flatpak install gnome-apps org.gnome.gedit stable
         %p
           Installed applications should appear in the usual place in your desktop. You can also run them from the command line:
         %pre
@@ -169,11 +169,11 @@
         %pre
           :preserve
             $ wget https://sdk.gnome.org/keys/gnome-sdk.gpg
-            $ flatpak remote-add --user --gpg-import=gnome-sdk.gpg gnome https://sdk.gnome.org/repo/
+            $ flatpak remote-add --gpg-import=gnome-sdk.gpg gnome https://sdk.gnome.org/repo/
         %p And then install the runtime itself:
         %pre
           :preserve
-            $ flatpak --user install gnome org.gnome.Platform 3.20
+            $ flatpak install gnome org.gnome.Platform 3.20
         %h3 3. Create your app
         %p
           First we need to create the directory structure for the app:
@@ -227,8 +227,8 @@
           This is done with two commands:
         %pre
           :preserve
-            flatpak --user remote-add --no-gpg-verify tutorial-repo repo
-            flatpak --user install tutorial-repo org.test.Hello
+            flatpak remote-add --no-gpg-verify tutorial-repo repo
+            flatpak install tutorial-repo org.test.Hello
         %h3 6. Run
         %p
           All that's left is to run the app. This can be done with:

--- a/source/runtimes.html.haml.markdown
+++ b/source/runtimes.html.haml.markdown
@@ -9,7 +9,7 @@
 
   Stable runtimes are currently available in Freedesktop and GNOME flavours. These are hosted at [https://sdk.gnome.org/repo/](https://sdk.gnome.org/repo/) and signed with the key at [https://sdk.gnome.org/keys/gnome-sdk.gpg](https://sdk.gnome.org/keys/gnome-sdk.gpg). The repository can be added with:
 
-      $ flatpak remote-add --user --gpg-import=gnome-sdk.gpg gnome https://sdk.gnome.org/repo/
+      $ flatpak remote-add --gpg-import=gnome-sdk.gpg gnome https://sdk.gnome.org/repo/
 
   GNOME runtimes are released with each major release and contain the main GNOME platform libraries. They are based on the official freedesktop.org runtime. At the moment they only receive minor bug fixing and security updates, but should be considered ABI stable and frozen.
 
@@ -72,7 +72,7 @@
 
   The nightly repository is available at [https://sdk.gnome.org/nightly/repo/](https://sdk.gnome.org/nightly/repo/). All releases are manually signed with the key at [https://sdk.gnome.org/nightly/keys/nightly.gpg](https://sdk.gnome.org/nightly/keys/nightly.gpg). This repository can be added with
 
-      $ flatpak --user remote-add --gpg-import=nightly.gpg gnome-nightly https://sdk.gnome.org/nightly/repo/
+      $ flatpak remote-add --gpg-import=nightly.gpg gnome-nightly https://sdk.gnome.org/nightly/repo/
 
   ### Available nightly runtimes
 
@@ -144,8 +144,8 @@
   
   Additionally there is a repo with nightly builds of some GNOME applications, which can be listed with:
 
-      $ flatpak --user remote-add --gpg-import=nightly.gpg gnome-nightly-apps https://sdk.gnome.org/nightly/repo-apps/
-      $ flatpak --user remote-ls gnome-nightly-apps --app
+      $ flatpak remote-add --gpg-import=nightly.gpg gnome-nightly-apps https://sdk.gnome.org/nightly/repo-apps/
+      $ flatpak remote-ls gnome-nightly-apps --app
 
   This includes the following apps:
 
@@ -174,10 +174,10 @@
 
   All these apps are using a version name of "master". For example, to install gedit run:
 
-      $ flatpak --user install gnome-nightly-apps org.gnome.gedit master
+      $ flatpak install gnome-nightly-apps org.gnome.gedit master
 
   And to update it:
 
-      $ flatpak --user update org.gnome.gedit master
+      $ flatpak update org.gnome.gedit master
 
 </div></div></div></section>

--- a/source/runtimes.html.haml.markdown
+++ b/source/runtimes.html.haml.markdown
@@ -3,13 +3,13 @@
 
   # Runtimes
 
-  This page lists the runtimes that are currently available for xdg-app.
+  This page lists the runtimes that are currently available for flatpak.
 
   ## Stable Runtimes
 
   Stable runtimes are currently available in Freedesktop and GNOME flavours. These are hosted at [https://sdk.gnome.org/repo/](https://sdk.gnome.org/repo/) and signed with the key at [https://sdk.gnome.org/keys/gnome-sdk.gpg](https://sdk.gnome.org/keys/gnome-sdk.gpg). The repository can be added with:
 
-      $ xdg-app remote-add --user --gpg-import=gnome-sdk.gpg gnome https://sdk.gnome.org/repo/
+      $ flatpak remote-add --user --gpg-import=gnome-sdk.gpg gnome https://sdk.gnome.org/repo/
 
   GNOME runtimes are released with each major release and contain the main GNOME platform libraries. They are based on the official freedesktop.org runtime. At the moment they only receive minor bug fixing and security updates, but should be considered ABI stable and frozen.
 
@@ -72,7 +72,7 @@
 
   The nightly repository is available at [https://sdk.gnome.org/nightly/repo/](https://sdk.gnome.org/nightly/repo/). All releases are manually signed with the key at [https://sdk.gnome.org/nightly/keys/nightly.gpg](https://sdk.gnome.org/nightly/keys/nightly.gpg). This repository can be added with
 
-      $ xdg-app --user remote-add --gpg-key=nightly.gpg gnome-nightly https://sdk.gnome.org/nightly/repo/
+      $ flatpak --user remote-add --gpg-key=nightly.gpg gnome-nightly https://sdk.gnome.org/nightly/repo/
 
   ### Available nightly runtimes
 
@@ -144,8 +144,8 @@
   
   Additionally there is a repo with nightly builds of some GNOME applications, which can be listed with:
 
-      $ xdg-app --user remote-add --gpg-key=nightly.gpg gnome-nightly-apps https://sdk.gnome.org/nightly/repo-apps/
-      $ xdg-app --user remote-ls gnome-nightly-apps --app
+      $ flatpak --user remote-add --gpg-key=nightly.gpg gnome-nightly-apps https://sdk.gnome.org/nightly/repo-apps/
+      $ flatpak --user remote-ls gnome-nightly-apps --app
 
   This includes the following apps:
 
@@ -170,14 +170,14 @@
       org.gnome.gedit
       org.gnome.iagno
 
-  Of particular interest is org.gnome.Software.XdgApp, which lets you browse and install xdg-app with a graphical tool.
+  Of particular interest is org.gnome.Software.XdgApp, which lets you browse and install flatpak apps with a graphical tool.
 
   All these apps are using a version name of "master". For example, to install gedit run:
 
-      $ xdg-app --user install gnome-nightly-apps org.gnome.gedit master
+      $ flatpak --user install gnome-nightly-apps org.gnome.gedit master
 
   And to update it:
 
-      $ xdg-app --user update org.gnome.gedit master
+      $ flatpak --user update org.gnome.gedit master
 
 </div></div></div></section>

--- a/source/runtimes.html.haml.markdown
+++ b/source/runtimes.html.haml.markdown
@@ -72,7 +72,7 @@
 
   The nightly repository is available at [https://sdk.gnome.org/nightly/repo/](https://sdk.gnome.org/nightly/repo/). All releases are manually signed with the key at [https://sdk.gnome.org/nightly/keys/nightly.gpg](https://sdk.gnome.org/nightly/keys/nightly.gpg). This repository can be added with
 
-      $ flatpak --user remote-add --gpg-key=nightly.gpg gnome-nightly https://sdk.gnome.org/nightly/repo/
+      $ flatpak --user remote-add --gpg-import=nightly.gpg gnome-nightly https://sdk.gnome.org/nightly/repo/
 
   ### Available nightly runtimes
 
@@ -144,7 +144,7 @@
   
   Additionally there is a repo with nightly builds of some GNOME applications, which can be listed with:
 
-      $ flatpak --user remote-add --gpg-key=nightly.gpg gnome-nightly-apps https://sdk.gnome.org/nightly/repo-apps/
+      $ flatpak --user remote-add --gpg-import=nightly.gpg gnome-nightly-apps https://sdk.gnome.org/nightly/repo-apps/
       $ flatpak --user remote-ls gnome-nightly-apps --app
 
   This includes the following apps:


### PR DESCRIPTION
* Replace xdg-app occurrences with flatpak
* Replace --gpg-key occurrences with --gpg-import
* Remove --user everywhere
* Add missing " in a command line example
* Fix more typos