### PR TITLE
Jjardon/link fixes

### DIFF
--- a/source/getting.html.haml.markdown
+++ b/source/getting.html.haml.markdown
@@ -35,7 +35,7 @@
 
   ### Arch
 
-  A `flatpak` package is available in the AUR.
+  A `flatpak` package is available in the official repositories.
 
   ### Mageia
 

--- a/source/index.html.haml
+++ b/source/index.html.haml
@@ -257,7 +257,7 @@
           or 
           %em flatpak
           IRC channel on Freenode. Code can be found on
-          %a{:href => "https://github.com/alexlarsson/xdg-app"} Github
+          %a{:href => "https://github.com/alexlarsson/flatpak/flatpak"} Github
           and issues are tracked on 
           = succeed "." do
-            %a{:href => "https://bugs.freedesktop.org/enter_bug.cgi?product=xdg-app"} Freedesktop Bugzilla
+            %a{:href => "https://github.com/flatpak/flatpak/issues"} Github


### PR DESCRIPTION
2 little fixes:
- Fix links to current github repo and issue tracker
- Arch include flatpak in they official repos already