### PR TITLE
Generate meta tags automagically

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ source 'http://rubygems.org'
 
 gem "middleman" #, github: "middleman/middleman", branch: "v3-stable"
 gem "middleman-google-analytics", '~> 2.1'
+gem "middleman-meta-tags"
 #gem "middleman-blog"
 gem "middleman-livereload" #3.1.0
 #gem "nokogiri" #1.6.0 (xml html smarts)

--- a/config.rb
+++ b/config.rb
@@ -62,3 +62,6 @@ set :markdown, :tables => true #, :autolink => true, :gh_blockcode => true, :fen
 activate :google_analytics do |ga|
   ga.tracking_id = 'UA-68811788-1' # Replace with your property ID.
 end
+
+activate :meta_tags
+

--- a/data/site.yml
+++ b/data/site.yml
@@ -13,10 +13,8 @@ punchline: The Future of Application Distribution
 # Global meta tags on each page <>
 # To have page-specific tags added, please add a YAML list to "tags:"
 # in that page's frontmatter block (the part at the top between ---)
-keywords:
-  - xdgapp
-  - xdg
-  - zapp
-  - flatpack
-  - flatpak
+title: Flatpak
+site: The Future of Application Distribution
+description: "FIXME"
+keywords: xdg-app xdg zapp flatpack flatpak
 

--- a/source/layouts/layout.haml
+++ b/source/layouts/layout.haml
@@ -1,13 +1,12 @@
 !!!5
 %html
   %head
-    %title Flatpak
     %meta{content: "text/html; charset=UTF8", "http-equiv" => "content-type"}/
-    %meta{content: "fixme", name: "description"}/
-    %meta{content: "fixme", name: "keywords"}/
     %meta{content: "width=device-width,initial-scale=1", name: "viewport" }/ 
+    = auto_display_meta_tags
     %link{rel:"icon", "type" => "image/png", href:"/images/icons/favicon.png"}/
     %link{rel:"shortcut icon", "type" => "image/x-icon", href:"/favicon.ico"}/
+
     = stylesheet_link_tag :fonts
     = stylesheet_link_tag :site
     = stylesheet_link_tag :animate


### PR DESCRIPTION
With the 'middleman-meta-tags' gem can generate meta tags automatically, you just have to declare them with their values in the site.yml file.

Of course, needs to add more informtion to the site.yml to get all the benefit.