### PR TITLE
Use i386 for the example identifier, that is the standard name

### DIFF
--- a/source/developer.html.haml.markdown
+++ b/source/developer.html.haml.markdown
@@ -46,7 +46,7 @@
 
   Each application must be built against a runtime, and this runtime must be installed on a host system in order for the application to run. Users can install multiple different runtimes at the same time, including different versions of the same runtime.
 
-  Flatpak identifies runtimes (as well as SDKs and applications) by a triple of name/arch/branch. The name is expected to be in inverse-dns notation, which needs to match the D-Bus name used for the application. For example: '`org.gnome.Sdk/x86_64/3.14`' or '`org.gnome.Builder/i686/master`'.
+  Flatpak identifies runtimes (as well as SDKs and applications) by a triple of name/arch/branch. The name is expected to be in inverse-dns notation, which needs to match the D-Bus name used for the application. For example: '`org.gnome.Sdk/x86_64/3.14`' or '`org.gnome.Builder/i386/master`'.
 
   ### Bundled Libraries<a id="bundledlibraries"></a>
 


### PR DESCRIPTION
We don't use i686 for intel arches, only i386.