### PR TITLE
We don't need to do any custom setup on debian anymore

### DIFF
--- a/source/getting.html.haml.markdown
+++ b/source/getting.html.haml.markdown
@@ -29,18 +29,6 @@
   <span class="unselectable">$ </span>apt install flatpak
   </pre>
 
-  This will install Flatpak, but by default Debian disallows user-namespaces as non-root, which means Flatpak will not work. To enable this run:
-
-  <pre>
-  <span class="unselectable">$ </span>sysctl kernel.unprivileged_userns_clone=1
-  </pre>
-
-  To make this change permanent (after reboot), run:
-
-  <pre>
-  <span class="unselectable">$ </span>echo 'kernel.unprivileged_userns_clone = 1' > /etc/sysctl.d/10-unpriv-ns.conf
-  </pre>
-
   ### Arch
 
   A `flatpak` package is available in the official repositories.


### PR DESCRIPTION
We're now using a setuid helper, not user namespaces, so the
user ns workarounds are not needed.