### PR TITLE
remove video from users section

### DIFF
--- a/source/index.html.haml
+++ b/source/index.html.haml
@@ -65,12 +65,7 @@
             %li LibreOffice builds (TBD: link)
         %p
           In the near future, you will be able to install flatpaks painlessly from graphical tools
-          such as GNOME Software:
-
-        <p><iframe height="600" src="https://www.youtube.com/embed/RsNqT13uIQo?feature=oembed" frameborder="0" allowfullscreen class="full"></iframe></p>
-
-        %p
-          Until then, you can use the commandline tool to install and update flatpaks.
+          such as GNOME Software. Until then, you can use the commandline tool to install and update flatpaks.
 
         %h3 1. Install Flatpak
         %p


### PR DESCRIPTION
The demo video includes out of date instructions that use xdg-app.
The video also adds additional overhead - the goal of this section
is to get people up and running as quickly as possible.