### PR TITLE
add an apps page

### DIFF
--- a/source/apps.html.haml.markdown
+++ b/source/apps.html.haml.markdown
@@ -1,0 +1,92 @@
+<section class=""><div class="container"><div class="row"><div class="col-lg-10 col-lg-offset-1">
+:markdown
+
+  # Apps
+
+  A variety of apps are currently available to install as Flatpaks. This includes stable and nightly GNOME applications, and a collection of nightly graphics application builds.
+
+  ## Stable GNOME applications
+
+  A collection of GNOME applications are available from the latest upstream release (version 3.20). These can be found in the gnome-apps repository, which can be added with:
+
+      $ wget https://sdk.gnome.org/keys/gnome-sdk.gpg
+      $ flatpak remote-add --gpg-import=gnome-sdk.gpg gnome-apps https://sdk.gnome.org/repo-apps/
+
+  You can then list available apps using:
+
+      $ flatpak remote-ls gnome-apps --app
+
+  Applications in this repository require the 3.20 version of the org.gnome.Platform runtime: see the [runtimes page](runtimes.html) for details on how to install it.
+
+  Stable GNOME applictaions also use the version name of "stable". To install one, you therefore run:
+
+      $ flatpak install gnome-apps org.gnome.gedit stable
+
+  ## Nightly GNOME applications
+
+  The GNOME nightly apps repository includes a collection of GNOME applications that are built daily from Git master. It includes:
+
+      org.gnome.Builder
+      org.gnome.Calculator
+      org.gnome.Calendar
+      org.gnome.Characters
+      org.gnome.Dictionary
+      org.gnome.Documents
+      org.gnome.Epiphany
+      org.gnome.Evince
+      org.gnome.Games
+      org.gnome.Gitg
+      org.gnome.Glade
+      org.gnome.Maps
+      org.gnome.News
+      org.gnome.Polari
+      org.gnome.Rhythmbox
+      org.gnome.Todo
+      org.gnome.Totem
+      org.gnome.Weather
+      org.gnome.bijiben
+      org.gnome.clocks
+      org.gnome.eog
+      org.gnome.gedit
+      org.gnome.iagno
+
+  To add the GNOME nightly apps repository, run:
+
+      $ flatpak remote-add --gpg-import=nightly.gpg gnome-nightly-apps https://sdk.gnome.org/nightly/repo-apps/
+
+  And to list the apps in the repository:
+
+      $ flatpak remote-ls gnome-nightly-apps --app
+
+  These applications require the nightly version of the org.gnome.Platform runtime: see the [runtimes page](runtimes.html) for details on how to install this. All the apps in the repository use the version name of "master". For example, to install gedit run:
+
+      $ flatpak install gnome-nightly-apps org.gnome.gedit master
+
+  And to update it:
+
+      $ flatpak update org.gnome.gedit master
+
+  ## Nightly graphics apps
+
+  The nightly-graphics repository contains daily development builds of common graphics applications, including:
+
+  * Darktable
+  * GIMP
+  * GIMP GTK+3 branch
+  * Inkscape
+  * MyPaint
+
+  These applications require the org.gnome.Platform 3.20 runtime: see the [runtimes page](runtimes.html) for details on how to install this. To add the nightly-graphics repository, run:
+
+      $ wget http://209.132.179.2/keys/nightly.gpg
+      $ flatpak remote-add --user --gpg-import=nightly.gpg nightly-graphics http://209.132.179.2/repo/
+
+  List the apps in the repository:
+
+      $ flatpak remote-ls gnome-nightly-apps --app
+
+  The graphics apps use "master" as their version name, so to install one, run:
+
+      $ flatpak update org.gimp.GimpDevel master
+
+</div></div></div></section>

--- a/source/index.html.haml
+++ b/source/index.html.haml
@@ -56,13 +56,11 @@
           development or testing versions. And in the future, Flatpak's security first approach 
           guarantee greater privacy and peace of mind.
         %p
-          A collection of applications are available as Flatpaks, which you can try yourself.
-          %ul
-            %li
-              %a{:href => "https://wiki.gnome.org/Projects/SandboxedApps/NightlyGraphicsBuilds"} Nightly builds
-              of GIMP, InkScape, DarkTable, MyPaint, Scribus
-            %li Stable builds (TBD: link) of core GNOME applications
-            %li LibreOffice builds (TBD: link)
+          Various applications are available as Flatpaks, including stable and nightly
+          GNOME applications, and a collection of nightly builds of graphics applications like
+          GIMP, Inkscape and MyPaint. See the
+          %a{:href => "apps.html"} apps page
+          for more detals.
         %p
           In the near future, you will be able to install flatpaks painlessly from graphical tools
           such as GNOME Software:

--- a/source/runtimes.html.haml.markdown
+++ b/source/runtimes.html.haml.markdown
@@ -121,44 +121,5 @@
       <td>master</td>
     </tr>
   </table>
-  
-  Additionally there is a repo with nightly builds of some GNOME applications, which can be listed with:
-
-      $ flatpak remote-add --gpg-import=nightly.gpg gnome-nightly-apps https://sdk.gnome.org/nightly/repo-apps/
-      $ flatpak remote-ls gnome-nightly-apps --app
-
-  This includes the following apps:
-
-      org.gnome.Builder
-      org.gnome.Calculator
-      org.gnome.Calendar
-      org.gnome.Characters
-      org.gnome.Dictionary
-      org.gnome.Documents
-      org.gnome.Epiphany
-      org.gnome.Evince
-      org.gnome.Games
-      org.gnome.Gitg
-      org.gnome.Glade
-      org.gnome.Maps
-      org.gnome.News
-      org.gnome.Polari
-      org.gnome.Rhythmbox
-      org.gnome.Todo
-      org.gnome.Totem
-      org.gnome.Weather
-      org.gnome.bijiben
-      org.gnome.clocks
-      org.gnome.eog
-      org.gnome.gedit
-      org.gnome.iagno
-
-  All these apps are using a version name of "master". For example, to install gedit run:
-
-      $ flatpak install gnome-nightly-apps org.gnome.gedit master
-
-  And to update it:
-
-      $ flatpak update org.gnome.gedit master
 
 </div></div></div></section>


### PR DESCRIPTION
The runtimes page currently includes a list of apps, which isn't
very logical. Also, there are wiki pages with details of available
apps which need migrating over to github. This creates a new apps
page for storing this information.