### PR TITLE
Fix: Ignore hashing for .ico files

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -63,5 +63,5 @@ activate :google_analytics do |ga|
   ga.tracking_id = 'UA-68811788-1' # Replace with your property ID.
 end
 
-activate :asset_hash
+activate :asset_hash, :ignore => %w(.ico)
 


### PR DESCRIPTION
I know that is a "dirty" fix, but it work for now.