### PR TITLE
flatpak is not available yet in fedora 23

### DIFF
--- a/source/getting.html.haml.markdown
+++ b/source/getting.html.haml.markdown
@@ -28,7 +28,7 @@
   <pre>
   <span class="unselectable">$ </span>dnf install flatpak
   </pre>
-  
+
   ### Mageia
 
   A `flatpak` package is available in Cauldron.

--- a/source/getting.html.haml.markdown
+++ b/source/getting.html.haml.markdown
@@ -23,12 +23,12 @@
 
   ### Fedora
 
-  A `flatpak` package is available for Fedora 23 and newer. To install, run the following as root:
+  A `flatpak` package is available for Fedora 24 (and soon for Fedora 23). To install, run the following as root:
 
   <pre>
   <span class="unselectable">$ </span>dnf install flatpak
   </pre>
-
+  
   ### Mageia
 
   A `flatpak` package is available in Cauldron.

--- a/source/index.html.haml
+++ b/source/index.html.haml
@@ -94,7 +94,7 @@
           %a{:href => "getting.html"} getting Flatpak
           page.
         %p
-          With Fedora, run:
+          With Fedora 24, run:
         :preserve
           <pre>
           <span class="unselectable">$ </span>sudo dnf install flatpak


### PR DESCRIPTION
I made this change to avoid confusion as currently flatpak isn't available in fedora 23. One can see the status of flatpak on [bodhi](https://bodhi.fedoraproject.org/updates/?packages=flatpak) as well the [packages webapp](https://apps.fedoraproject.org/packages/flatpak).