### PR TITLE
Fixed menu typo, "Flatpack" should be "Flatpak"

### DIFF
--- a/data/menu.yml
+++ b/data/menu.yml
@@ -12,7 +12,7 @@
 - title: Build
   link: "#developers"
   submenu:
-  - title: Getting Started with Flatpack
+  - title: Getting Started with Flatpak
     link: developer.html
   - title: Bundling a Java Application with Flatpak
     link: bundling-a-java-app.html


### PR DESCRIPTION
Trivial fix, the menu title reads "Getting started with Flatpack", the c shouldn't be there.