### PR TITLE
Fix typo

### DIFF
--- a/source/index.html.haml
+++ b/source/index.html.haml
@@ -84,7 +84,7 @@ description: The days of chasing multiple Linux distributions are over. Standalo
           GNOME applications, and a collection of nightly builds of graphics applications like
           GIMP, Inkscape and MyPaint. See the
           %a{:href => "apps.html"} apps page
-          for more detals.
+          for more details.
         %p
           In the near future, you will be able to install flatpaks painlessly from graphical tools
           such as GNOME Software. Until then, you can use the commandline tool to install and update flatpaks.


### PR DESCRIPTION
Fix a typo in description `detals -> details`