### PR TITLE
add gnome 3.22 runtimes to the platform listing

### DIFF
--- a/source/runtimes.html.haml.markdown
+++ b/source/runtimes.html.haml.markdown
@@ -28,27 +28,27 @@ description: Currently available runtimes.
     <tr>
       <td>org.gnome.Platform</td>
       <td>The standard Gnome runtime used by most gnome apps</td>
-      <td>3.16, 3.18, 3.20</td>
+      <td>3.16, 3.18, 3.20, 3.22</td>
     </tr>
     <tr>
       <td>org.gnome.Platform.Locale</td>
       <td>Addins to org.gnome.Platform that adds locale data and translations</td>
-      <td>3.20</td>
+      <td>3.20, 3.22</td>
     </tr>
     <tr>
       <td>org.gnome.Sdk</td>
       <td>The development runtime used to build apps, and required by apps like gnome-builder</td>
-      <td>3.16, 3.18, 3.20</td>
+      <td>3.16, 3.18, 3.20, 3.22</td>
     </tr>
     <tr>
       <td>org.gnome.Sdk.Locale</td>
       <td>Locale info addin for org.gnome.Sdk</td>
-      <td>3.20</td>
+      <td>3.20. 3.22</td>
     </tr>
     <tr>
       <td>org.gnome.Sdk.Debug</td>
       <td>Debug info addin for org.gnome.Sdk</td>
-      <td>3.20</td>
+      <td>3.20, 3.22</td>
     </tr>
     <tr>
       <td>org.freedesktop.Platform</td>


### PR DESCRIPTION
Fixes issue #99