### PR TITLE
Stop saying Flatpak is only in Debian experimental

### DIFF
--- a/source/getting.html.haml.markdown
+++ b/source/getting.html.haml.markdown
@@ -14,7 +14,12 @@ description: How to download and install Flatpak on your system to get started.
 
   ### Debian
 
-  An in-development official `flatpak` package is available in [Debian Experimental](https://wiki.debian.org/DebianExperimental).
+  An official `flatpak` package is available in Debian testing and unstable. To install, run the following as root:
+
+  <pre>
+  <span class="unselectable">$ </span>apt update
+  <span class="unselectable">$ </span>apt install flatpak
+  </pre>
 
   For Debian Jessie, there is a custom apt repository available. To install, run the following as root:
 


### PR DESCRIPTION
At the time of writing, Flatpak 0.6.11 (the latest) is available in Debian testing and unstable. New releases are usually in unstable within a few days, and testing around a week later.

(I've also just uploaded the first official backports for Debian stable, which can replace Alexander's unofficial backports when accepted into `jessie-backports`; I'll send another PR when those are ready.)