### PR TITLE
Recommend the official Debian backport of Flatpak

### DIFF
--- a/source/getting.html.haml.markdown
+++ b/source/getting.html.haml.markdown
@@ -16,15 +16,7 @@ description: How to download and install Flatpak on your system to get started.
 
   A `flatpak` package is available in [Debian Testing](https://wiki.debian.org/DebianTesting) and newer.
 
-  For Debian Jessie, there is a custom apt repository available. To install, run the following as root:
-
-  <pre>
-  <span class="unselectable">$ </span>wget -O - https://sdk.gnome.org/apt/debian/conf/alexl.gpg.key|apt-key add -
-  <span class="unselectable">$ </span>echo "deb [arch=amd64] https://sdk.gnome.org/apt/debian/ jessie main" > /etc/apt/sources.list.d/flatpak.list
-  <span class="unselectable">$ </span>apt install apt-transport-https
-  <span class="unselectable">$ </span>apt update
-  <span class="unselectable">$ </span>apt install flatpak
-  </pre>
+  For Debian Jessie, a `flatpak` package is available in the official [backports repository](https://backports.debian.org/Instructions/).
 
   ### Fedora
 


### PR DESCRIPTION
---

I've uploaded `flatpak`, `ostree` and `bubblewrap` to the official Debian `jessie-backports` repository. They will typically get updated a few days after `unstable` unless a security vulnerability was fixed, because the policy for official backports is that they come from `testing` and not `unstable`.

@alexlarsson: if you want to keep doing unofficial backports on `sdk.gnome.org` please do, but if you have been basing them on the Debian `unstable` packages or the `debian/master` branch of [collab-maint/flatpak.git](https://anonscm.debian.org/cgit/collab-maint/flatpak.git), please switch to the `jessie-backports` packages or the `debian/jessie-backports` branch. The `debian/master` branch now requires packages and versions that aren't available in Jessie, whereas the `debian/jessie-backports` branch will continue to be patched for Jessie compatibility.