### PR TITLE
[getting] $-># for root commands

### DIFF
--- a/source/getting.html.haml.markdown
+++ b/source/getting.html.haml.markdown
@@ -37,13 +37,13 @@ description: How to download and install Flatpak on your system to get started.
   If using `DNF`
 
   <pre>
-  <span class="unselectable">$ </span>dnf install flatpak
+  <span class="unselectable"># </span>dnf install flatpak
   </pre>
 
   If using `urpmi`
 
   <pre>
-  <span class="unselectable">$ </span>urpmi flatpak
+  <span class="unselectable"># </span>urpmi flatpak
   </pre>
 
   ### openSUSE


### PR DESCRIPTION
`$` usually indicates standard (non-root) user console. I know that before the Mageia commands you's do say:

> run the following as root

but I think it might be best to use the `#` (which usually denotes root console) symbol instead of `$` for these root commands, just to avoid some confusion.