### PR TITLE
Switch LibreOffice to their flatpakref

### DIFF
--- a/source/apps.html.haml
+++ b/source/apps.html.haml
@@ -26,7 +26,7 @@ description: Applications distributed as Flatpaks, ready to download.
               Cauldron.
 
             .appslist.row            
-              = app_download "Libre Office", "http://download.documentfoundation.org/libreoffice/flatpak/latest/LibreOffice.flatpak"
+              = app_download "LibreOffice", "http://download.documentfoundation.org/libreoffice/flatpak/LibreOffice.flatpakref"
               = app_download "Telegram", "https://jgrulich.fedorapeople.org/telegram/telegram.flatpakref"
               = app_download "Spotify", "https://s3.amazonaws.com/alexlarsson/spotify-repo/spotify.flatpakref"
               = app_download "Skype", "https://s3.amazonaws.com/alexlarsson/skype-repo/skype.flatpakref"


### PR DESCRIPTION
LibreOffice now has a repo rather than just a standalone bundle:

http://www.libreoffice.org/download/flatpak/

It's a much better user experience to get ongoing updates from the source.