### PR TITLE
apps: Clarify Transmission name

### DIFF
--- a/source/apps.html.haml
+++ b/source/apps.html.haml
@@ -37,7 +37,7 @@ description: Applications distributed as Flatpaks, ready to download.
             .appslist.row
               = app_download "GNOME Twitch", "https://dl.tingping.se/flatpak/gnome-twitch.flatpakref"
               = app_download "Pithos", "https://dl.tingping.se/flatpak/pithos.flatpakref"
-              = app_download "Transmission", "https://dl.tingping.se/flatpak/transmission-remote-gtk.flatpakref"
+              = app_download "Transmission Remote Gtk", "https://dl.tingping.se/flatpak/transmission-remote-gtk.flatpakref"
               / = app_download "Pitivi", "#"
               = app_download "GNOME MPV", "https://dl.tingping.se/flatpak/gnome-mpv.flatpakref"
               / = app_download "Corebird", "#"


### PR DESCRIPTION
These are separate projects so it is best to have the full name.