### PR TITLE
Point out working directory in step 4 of tutorial

### DIFF
--- a/source/hello-world.html.haml.markdown
+++ b/source/hello-world.html.haml.markdown
@@ -74,7 +74,7 @@ description: Create a Flatpak application in five minutes.
 
   ## 4. Put the app in a repository
 
-  Congratulations, you've made an app! To be able to install it, you need to put it in a repository. This is done with the build-export command:
+  Congratulations, you've made an app! To be able to install it, you need to put it in a repository. This is done with the build-export command. Make sure you are in the parent directory of `hello/` and run the following:
 
   <pre>
   <span class="unselectable">$ </span>flatpak build-export repo hello


### PR DESCRIPTION
Since step 3 is about files inside the `hello` directory, it is not immediately obvious that in step 4 `flatpak build-export` needs to be executed in the parent directory of `hello/`. This might lead to some frustrating debugging or the impression that the tutorial/documentation is outdated or flatpak is broken. The additional instruction hopefully prevents this.

See #69 for another case where such a note would have been helpful.