### PR TITLE
Missing word "it" in Server FAQ sentence.  

### DIFF
--- a/source/faq.html.haml.markdown
+++ b/source/faq.html.haml.markdown
@@ -69,7 +69,7 @@ description: FAQ about the Flatpak project.
 
   ### Can Flatpak be used on servers too?
   
-  Flatpak is designed to run inside a desktop session and relies on certain session services, such as a dbus session bus and a systemd --user instance. So, is not a good match for a server.
+  Flatpak is designed to run inside a desktop session and relies on certain session services, such as a dbus session bus and a systemd --user instance. This makes Flatpak not a good match for a server.
 
   However, the build features of Flatpak run fine outside a session, so you can build things on a server.
 


### PR DESCRIPTION
Re-worked sentence for better grammar and structure.  Sentence now reads:  

This makes Flatpak not a good match for a server.