### PR TITLE
Move the GNOME apps to the new "stable" branch

### DIFF
--- a/source/apps.html.haml
+++ b/source/apps.html.haml
@@ -263,21 +263,21 @@ description: Applications distributed as Flatpaks, ready to download.
             %h5 Builder
             %pre
               :preserve
-                <span class="unselectable">$ </span>flatpak install --from https://git.gnome.org/browse/gnome-apps-nightly/plain/gnome-builder.flatpakref?h=gnome-3-22
+                <span class="unselectable">$ </span>flatpak install --from https://git.gnome.org/browse/gnome-apps-nightly/plain/gnome-builder.flatpakref?h=stable
                 <span class="unselectable">$ </span>flatpak run org.gnome.Builder
 
             %a{:name => "documents-stable"}
             %h5 Documents
             %pre
               :preserve
-                <span class="unselectable">$ </span>flatpak install --from https://git.gnome.org/browse/gnome-apps-nightly/plain/gnome-documents.flatpakref?h=gnome-3-22
+                <span class="unselectable">$ </span>flatpak install --from https://git.gnome.org/browse/gnome-apps-nightly/plain/gnome-documents.flatpakref?h=stable
                 <span class="unselectable">$ </span>flatpak run org.gnome.Documents
 
             %a{:name => "photos-stable"}
             %h5 Photos
             %pre
               :preserve
-                <span class="unselectable">$ </span>flatpak install --from https://git.gnome.org/browse/gnome-apps-nightly/plain/gnome-photos.flatpakref?h=gnome-3-22
+                <span class="unselectable">$ </span>flatpak install --from https://git.gnome.org/browse/gnome-apps-nightly/plain/gnome-photos.flatpakref?h=stable
                 <span class="unselectable">$ </span>flatpak run org.gnome.Photos
 
             %a{:name => "recipes"}


### PR DESCRIPTION
This is a followup on #151, where @allanday correctly pointed out I had only done half of the work.