### PR TITLE
Remove periods from end of app description sentences

### DIFF
--- a/source/apps.html.haml
+++ b/source/apps.html.haml
@@ -26,37 +26,37 @@ description: Applications distributed as Flatpaks, ready to download.
               Cauldron, using GNOME Software. Some applications require the latest version, 3.22.6.
 
             .appslist.row            
-              = app_download "LibreOffice", "Popular office suite, direct from the developers.", "http://download.documentfoundation.org/libreoffice/flatpak/LibreOffice.flatpakref"
-              = app_download "Telegram", "Secure instant messaging.", "https://jgrulich.fedorapeople.org/telegram/telegram.flatpakref"
-              = app_download "Spotify", "Music, podcast and video streaming service.", "https://s3.amazonaws.com/alexlarsson/spotify-repo/spotify.flatpakref"
-              = app_download "Skype", "Internet video and chat.", "https://s3.amazonaws.com/alexlarsson/skype-repo/skype.flatpakref"
+              = app_download "LibreOffice", "Popular office suite, direct from the developers", "http://download.documentfoundation.org/libreoffice/flatpak/LibreOffice.flatpakref"
+              = app_download "Telegram", "Secure instant messaging", "https://jgrulich.fedorapeople.org/telegram/telegram.flatpakref"
+              = app_download "Spotify", "Music, podcast and video streaming service", "https://s3.amazonaws.com/alexlarsson/spotify-repo/spotify.flatpakref"
+              = app_download "Skype", "Internet video and chat", "https://s3.amazonaws.com/alexlarsson/skype-repo/skype.flatpakref"
               = app_download "MonoDevelop", "Cross platform IDE for C#, F# and more", "https://download.mono-project.com/repo/monodevelop.flatpakref"
-              = app_download "Blender", "Open Source 3D creation.", "https://www.daitauha.fr/static/flatpak/blender.flatpakref"
+              = app_download "Blender", "Open Source 3D creation", "https://www.daitauha.fr/static/flatpak/blender.flatpakref"
 
                   
             .appslist.row
-              = app_download "GNOME Twitch", "Watch live internet video broadcasts.", "https://dl.tingping.se/flatpak/gnome-twitch.flatpakref"
-              = app_download "Pithos", "Radio client for the Pandora music service.", "https://dl.tingping.se/flatpak/pithos.flatpakref"
-              = app_download "Transmission Remote", "Frontend for the Transmission server, built using GTK+.", "https://dl.tingping.se/flatpak/transmission-remote-gtk.flatpakref"
-              = app_download "Pitivi", "Personal video editing.", "http://flatpak.pitivi.org/pitivi.flatpakref"
-              = app_download "GNOME MPV", "Video player.", "https://dl.tingping.se/flatpak/gnome-mpv.flatpakref"
-              = app_download "Corebird", "Twitter client for Linux.", "http://baedert.org/repo/org.baedert.corebird.flatpakref"
-              = app_download "Picard", "Music metadata editor.", "https://www.daitauha.fr/static/flatpak/picard.flatpakref"
-              = app_download "FeedReader", "Internet RSS Newsfeed Reader.", "http://feedreader.xarbit.net/feedreader-repo/feedreader.flatpakref"
-              = app_download "Peek", "Short screencapture software that outputs GIF images.", "http://flatpak.uploadedlobster.com/peek-stable.flatpakref"
+              = app_download "GNOME Twitch", "Watch live internet video broadcasts", "https://dl.tingping.se/flatpak/gnome-twitch.flatpakref"
+              = app_download "Pithos", "Radio client for the Pandora music service", "https://dl.tingping.se/flatpak/pithos.flatpakref"
+              = app_download "Transmission Remote", "Frontend for the Transmission server, built using GTK+", "https://dl.tingping.se/flatpak/transmission-remote-gtk.flatpakref"
+              = app_download "Pitivi", "Personal video editing", "http://flatpak.pitivi.org/pitivi.flatpakref"
+              = app_download "GNOME MPV", "Video player", "https://dl.tingping.se/flatpak/gnome-mpv.flatpakref"
+              = app_download "Corebird", "Twitter client for Linux", "http://baedert.org/repo/org.baedert.corebird.flatpakref"
+              = app_download "Picard", "Music metadata editor", "https://www.daitauha.fr/static/flatpak/picard.flatpakref"
+              = app_download "FeedReader", "Internet RSS Newsfeed Reader", "http://feedreader.xarbit.net/feedreader-repo/feedreader.flatpakref"
+              = app_download "Peek", "Short screencapture software that outputs GIF images", "http://flatpak.uploadedlobster.com/peek-stable.flatpakref"
 
 
             .appslist.row
               .col-xs-12
                 .row
                   %h4.col-xs-12 GNOME Stable Apps
-                  = app_download "Builder", "IDE for GNOME.", "https://git.gnome.org/browse/gnome-apps-nightly/plain/gnome-builder.flatpakref?h=stable"
-                  = app_download "Documents", "Manage your local and online documents.", "https://git.gnome.org/browse/gnome-apps-nightly/plain/gnome-documents.flatpakref?h=stable"
-                  = app_download "Gedit", "Text editor.", "https://git.gnome.org/browse/gnome-apps-nightly/plain/gedit.flatpakref?h=stable"
-                  = app_download "Photos", "Access, organize and share your photos.", "https://git.gnome.org/browse/gnome-apps-nightly/plain/gnome-photos.flatpakref?h=stable"
-                  = app_download "Polari", "IRC chat client.", "https://git.gnome.org/browse/gnome-apps-nightly/plain/polari.flatpakref?h=stable"
-                  = app_download "Recipes", "Discover what to cook.", "https://matthiasclasen.github.io/recipes-releases/gnome-recipes.flatpakref"
-                  = app_download "Weather", "Monitor the weather anywhere.", "https://git.gnome.org/browse/gnome-apps-nightly/plain/gnome-weather.flatpakref?h=stable"
+                  = app_download "Builder", "IDE for GNOME", "https://git.gnome.org/browse/gnome-apps-nightly/plain/gnome-builder.flatpakref?h=stable"
+                  = app_download "Documents", "Manage your local and online documents", "https://git.gnome.org/browse/gnome-apps-nightly/plain/gnome-documents.flatpakref?h=stable"
+                  = app_download "Gedit", "Text editor", "https://git.gnome.org/browse/gnome-apps-nightly/plain/gedit.flatpakref?h=stable"
+                  = app_download "Photos", "Access, organize and share your photos", "https://git.gnome.org/browse/gnome-apps-nightly/plain/gnome-photos.flatpakref?h=stable"
+                  = app_download "Polari", "IRC chat client", "https://git.gnome.org/browse/gnome-apps-nightly/plain/polari.flatpakref?h=stable"
+                  = app_download "Recipes", "Discover what to cook", "https://matthiasclasen.github.io/recipes-releases/gnome-recipes.flatpakref"
+                  = app_download "Weather", "Monitor the weather anywhere", "https://git.gnome.org/browse/gnome-apps-nightly/plain/gnome-weather.flatpakref?h=stable"
 
             .appslist.row
               .col-xs-12


### PR DESCRIPTION
Remove periods from the end of the sentences describing the apps
available via Flatpak.  Per Allan's comment on issue 155: https://github.com/flatpak/flatpak.github.io/issues/155