### PR TITLE
apps: Remove unnecessary newlines and tabs

### DIFF
--- a/source/apps.html.haml
+++ b/source/apps.html.haml
@@ -185,7 +185,6 @@ description: Applications distributed as Flatpaks, ready to download.
               :preserve
                 <span class="unselectable">$ </span>flatpak install --user http://flatpak.pitivi.org/pitivi.flatpakref
 
-
             You can now launch Pitivi from your applications menu as any other installed application. You can also re run the installer which launches Pitivi after updating to the latest version. To see if warning or error messages are printed in the console, run: 
             %pre
               :preserve
@@ -203,13 +202,12 @@ description: Applications distributed as Flatpaks, ready to download.
             = link_to "Corebird", "http://corebird.baedert.org/"
             releases are being produced by
             = link_to "Timm Bäder", "http://baedert.org/"
-            
+
             %pre
               :preserve
                 <span class="unselectable">$ </span>flatpak install --from https://raw.githubusercontent.com/baedert/corebird-flatpak/master/org.baedert.corebird.flatpakref
                 <span class="unselectable">$ </span>flatpak run org.baedert.corebird
-                
-            
+
             %a{:name => "feedreader"}
             %h4 FeedReader
 


### PR DESCRIPTION
Fixes broken pre for Pitivi and Corebird.

![pitivi](https://cloud.githubusercontent.com/assets/2339930/25058187/1bb16092-2177-11e7-8861-ff288e12587d.png)