### PR TITLE
Add Arch elfutils as needed for flatpak-builder

### DIFF
--- a/source/getting.html.haml.markdown
+++ b/source/getting.html.haml.markdown
@@ -25,7 +25,9 @@ description: How to download and install Flatpak on your system to get started.
   <pre>
   <span class="unselectable">$ </span>sudo pacman -S flatpak
   </pre>
-  For development of Flatpak applications, `flatpak-builder` is available and it requires these tools to work properly.
+  
+  For development of Flatpak applications using `flatpak-builder` these dependencies are required:
+  
   <pre>
   <span class="unselectable">$ </span>sudo pacman -S --asdeps elfutils patch
   </pre>

--- a/source/getting.html.haml.markdown
+++ b/source/getting.html.haml.markdown
@@ -25,6 +25,10 @@ description: How to download and install Flatpak on your system to get started.
   <pre>
   <span class="unselectable">$ </span>sudo pacman -S flatpak
   </pre>
+  For development of Flatpak applications, `flatpak-builder` is available.
+  <pre>
+  <span class="unselectable">$ </span>sudo pacman -S flatpak-builder elfutils
+  </pre>
 
   ### Debian
 

--- a/source/getting.html.haml.markdown
+++ b/source/getting.html.haml.markdown
@@ -29,7 +29,7 @@ description: How to download and install Flatpak on your system to get started.
   For development of Flatpak applications using `flatpak-builder` these dependencies are required:
   
   <pre>
-  <span class="unselectable">$ </span>sudo pacman -S --asdeps elfutils patch
+  <span class="unselectable">$ </span>sudo pacman -S --asdeps --needed elfutils patch
   </pre>
 
   ### Debian

--- a/source/getting.html.haml.markdown
+++ b/source/getting.html.haml.markdown
@@ -25,7 +25,7 @@ description: How to download and install Flatpak on your system to get started.
   <pre>
   <span class="unselectable">$ </span>sudo pacman -S flatpak
   </pre>
-  For development of Flatpak applications, `flatpak-builder` is available.
+  For development of Flatpak applications, `flatpak-builder` is available and it requires these tools to work properly.
   <pre>
   <span class="unselectable">$ </span>sudo pacman -S --asdeps elfutils patch
   </pre>

--- a/source/getting.html.haml.markdown
+++ b/source/getting.html.haml.markdown
@@ -27,7 +27,7 @@ description: How to download and install Flatpak on your system to get started.
   </pre>
   For development of Flatpak applications, `flatpak-builder` is available.
   <pre>
-  <span class="unselectable">$ </span>sudo pacman -S flatpak-builder elfutils
+  <span class="unselectable">$ </span>sudo pacman -S --asdeps elfutils patch
   </pre>
 
   ### Debian


### PR DESCRIPTION
Arch doesn't install opt-depts by default, so flatpak-builder is broken on those system for a simple sudo pacman -S flatpak.

So document that they need to install it so developers of Flatpak applications doesn't have the problem of eu-strip not working.