### PR TITLE
Update Mageia install instructions for Mageia 6

### DIFF
--- a/source/getting.html.haml.markdown
+++ b/source/getting.html.haml.markdown
@@ -52,7 +52,7 @@ description: How to download and install Flatpak on your system to get started.
 
   ### Mageia
 
-  A `flatpak` package is available in Cauldron. To install, run the following as root:
+  A `flatpak` package is available for Mageia 6 and newer. To install, run the following as root:
 
   If using `DNF`
 


### PR DESCRIPTION
Starting with Mageia 6, flatpak is available in the official repositories.