### PR TITLE
getting: add stub instructions for Endless OS

### DIFF
--- a/source/getting.html.haml.markdown
+++ b/source/getting.html.haml.markdown
@@ -41,6 +41,10 @@ description: How to download and install Flatpak on your system to get started.
   </pre>
 
   For Debian Jessie, a `flatpak` package is available in the official [backports repository](https://backports.debian.org/Instructions/).
+  
+  ### Endless OS
+  
+  Flatpak support is built into Endless OS 3.0.0 and newer. If you are using an older version, [upgrade to Endless OS 3](https://community.endlessos.com/t/upgrade-from-endless-os-2-x-to-endless-os-3/967).
 
   ### Fedora
 


### PR DESCRIPTION
A user on our forum was confused: they'd been told to install apps using Flatpak, but couldn't find any instructions on Flatpak.org to install Flatpak itself on Endless OS.