### PR TITLE
Rework distribution support statement for click-to-download feature

### DIFF
--- a/source/apps.html.haml
+++ b/source/apps.html.haml
@@ -23,8 +23,8 @@ description: Applications distributed as Flatpaks, ready to download.
 
 
             %p
-              Click to download is available with Fedora 25, OpenSUSE Tumbleweed, Debian Testing, Arch, and Mageia 
-              Cauldron, using GNOME Software. Some applications require version 3.22.6 or later.
+              Click to download is available with Fedora 25 (and newer), Mageia 6 (and newer), OpenSUSE Tumbleweed, 
+              Debian 9 (and newer), and Arch, using GNOME Software. Some applications require version 3.22.6 or later.
 
             .appslist.row            
               .col-xs-12


### PR DESCRIPTION
More stable distribution releases ship with GNOME Software 3.22, which provides the capability to do fully graphical management of Flatpaks.