### PR TITLE
Update runtime information

### DIFF
--- a/source/runtimes.html.haml
+++ b/source/runtimes.html.haml
@@ -57,17 +57,20 @@ description: Available Flatpak runtimes.
                   %td org.freedesktop.Platform
                   %td Runtime
                 %tr
-                  %td org.freedesktop.Platform.locale
+                  %td org.freedesktop.Platform.Locale
                   %td Runtime translations (extension)
                 %tr
                   %td org.freedesktop.Sdk
                   %td SDK
                 %tr
-                  %td org.freedesktop.Sdk.debug
+                  %td org.freedesktop.Sdk.Debug
                   %td SDK debug information (extension)
                 %tr
-                  %td org.freedesktop.Sdk.locale
+                  %td org.freedesktop.Sdk.Locale
                   %td SDK translations (extension)
+                %tr
+                  %td org.freedesktop.Sdk.Docs
+                  %td SDK documentation (extension)
 
             %h3 Runtime details
             %p
@@ -78,6 +81,9 @@ description: Available Flatpak runtimes.
                  alsa-lib 1.1.3
                  alsa-plugins 1.1.1
                  aspell 0.60.6.1
+                 at-spi2-atk 2.24.1
+                 at-spi2-core 2.24.1
+                 atk 2.24.0
                  attr 2.4.47
                  autoconf-archive 2016.09.16
                  base-files qemux86_64 3.0.14
@@ -107,6 +113,7 @@ description: Available Flatpak runtimes.
                  glib-networking 2.50.0
                  glib2 2.52.2
                  glibc 2.24
+                 gtk 3.22.26
                  gnu-free-fonts 20120503
                  gnupg 2.1.14
                  gobject-introspection 1.52.1
@@ -271,7 +278,7 @@ description: Available Flatpak runtimes.
                  openssl-conf 1.0.2j
                  orc 0.4.26
                  p11-kit 0.23.2
-                 pango 1.40.5
+                 pango 1.40.12
                  pcre2 10.22
                  pinentry 0.9.2
                  pixman 0.34.0
@@ -365,28 +372,31 @@ description: Available Flatpak runtimes.
                   %td org.gnome.Platform
                   %td Runtime
                 %tr
-                  %td org.gnome.Platform.locale
+                  %td org.gnome.Platform.Locale
                   %td Runtime translations (extension)
                 %tr
                   %td org.gnome.Sdk
                   %td SDK
                 %tr
-                  %td org.gnome.Sdk.debug
+                  %td org.gnome.Sdk.Debug
                   %td SDK debug information (extension)
                 %tr
-                  %td org.gnome.Sdk.locale
+                  %td org.gnome.Sdk.Locale
                   %td SDK translations (extension)
+                %tr
+                  %td org.gnome.Sdk.Docs
+                  %td SDK documentation (extension)
 
             %h3 Runtime details
             %p
-              The latest version of the GNOME runtime is 3.24. It includes everything from the 1.6 Freedesktop runtime, as well as:
+              The latest version of the GNOME runtime is 3.26. It includes everything from the 1.6 Freedesktop runtime, as well as:
 
             %pre.capheight
               :preserve
-                 adwaita-icon-theme 3.24.0
-                 at-spi2-atk 2.24.0
-                 at-spi2-core 2.24.0
-                 atk 2.24.0
+                 adwaita-icon-theme 3.26.0
+                 at-spi2-atk 2.26.0
+                 at-spi2-core 2.26.0
+                 atk 2.26.0
                  cantarell-fonts 0.0.25
                  clutter 1.26.0
                  clutter-gst 3.0.22
@@ -398,33 +408,32 @@ description: Available Flatpak runtimes.
                  gcab 0.7
                  gcr 3.20.0
                  gdk-pixbuf 2.36.6
-                 gjs 1.48.0
-                 glib 2.52.2
-                 glib-networking 2.50.0
+                 gjs 1.50.1
+                 glib 2.54.1
+                 glib-networking 2.54.0
                  gnome-common 3.18.0
                  gnome-themes-standard 3.22.3
-                 gobject-introspection 1.52.1
-                 gsettings-desktop-schemas 3.24.0
+                 gobject-introspection 1.54.1
+                 gsettings-desktop-schemas 3.26.0
                  gtk2 2.24.31
-                 gtk3 3.22.15
-                 gvfs 1.32.1
-                 json-glib 1.2.8
+                 gtk3 3.22.26
+                 gvfs 1.34.1
+                 json-glib 1.4.2
                  libcanberra 0.30
                  libcroco 0.6.11
                  libdatrie 0.2.9
                  libnotify 0.7.6
                  librsvg 2.40.16
                  libsecret 0.18.5
-                 libsoup 2.58.1
+                 libsoup 2.60.0
                  libthai 0.1.22
-                 mozjs38 38.2.1
-                 pango 1.40.5
-                 pycairo 1.10.0
-                 pygobject 3.24.1
+                 mozjs 0.52
+                 pycairo 1.12.0
+                 pygobject 3.26.0
                  python-gstreamer 1.10.4
-                 vala 0.36.1
-                 vte 0.48.2
-                 webkitgtk4 2.16.2
+                 vala 0.38.2
+                 vte 0.50.1
+                 webkitgtk4 2.18.2
                  yelp 3.22.0
                  yelp-tools 3.18.0
                  yelp-xsl 3.20.1
@@ -457,17 +466,20 @@ description: Available Flatpak runtimes.
                   %td org.gnome.Platform
                   %td Runtime
                 %tr
-                  %td org.gnome.Platform.locale
+                  %td org.gnome.Platform.Locale
                   %td Runtime translations (extension)
                 %tr
                   %td org.gnome.Sdk
                   %td SDK
                 %tr
-                  %td org.gnome.Sdk.debug
+                  %td org.gnome.Sdk.Debug
                   %td SDK debug information (extension)
                 %tr
-                  %td org.gnome.Sdk.locale
+                  %td org.gnome.Sdk.Docale
                   %td SDK translations (extension)
+                %tr
+                  %td org.gnome.Sdk.Docs
+                  %td SDK documentation (extension)
 
           %div#kde.tab-pane.fade{:role => "tabpanel"}
 
@@ -494,17 +506,20 @@ description: Available Flatpak runtimes.
                   %td org.kde.Platform
                   %td Runtime
                 %tr
-                  %td org.kde.Platform.locale
+                  %td org.kde.Platform.Locale
                   %td Runtime translations (extension)
                 %tr
                   %td org.kde.Sdk
                   %td SDK
                 %tr
-                  %td org.kde.Sdk.debug
+                  %td org.kde.Sdk.Debug
                   %td SDK debug information (extension)
                 %tr
-                  %td org.kde.Sdk.locale
+                  %td org.kde.Sdk.Locale
                   %td SDK translations (extension)
+                %tr
+                  %td org.kde.Sdk.Docs
+                  %td SDK documentation (extension)
 
 :javascript
 $(function () {


### PR DESCRIPTION
Some extension names were missspelled.
org.*.Sdk.Docs was added.
Latest gnome is 3.26