### PR TITLE
Fix broken link to flathub.org apps page

### DIFF
--- a/data/menu.yml
+++ b/data/menu.yml
@@ -1,5 +1,5 @@
 - title: Find Applications
-  link: "http://flathub.org/apps"
+  link: "https://flathub.org/apps.html"
   onlyfooter: true
 - title: Developer Documentation
   link: "http://docs.flatpak.org/"


### PR DESCRIPTION
Missing .html extension was resulting in a 404.