### PR TITLE
readme: add missing steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,12 @@ Flatpak.org website
 
 To set up middleman locally on Fedora:
 
-install ruby, rubygems and rubygem-bundler
+    dnf install ruby rubygems rubygem-bundler rubygem-json
 
 In the git checkout, do a `bundle install`. This installs all 
 the needed modules in their appropriate vesions.
+
+Add the middleman binary location (probably ~/bin) to $PATH.
 
 To run a local web server to test the site:
 
@@ -20,4 +22,5 @@ to deploy your changes:
     bundle exec middleman build
     bundle exec middleman deploy
 
-This will push the site from ./build into origin/master branch.
+This will push the site from ./build into origin/master branch. 
+The flatpak sysadmins then have to update the live site.


### PR DESCRIPTION
Add an additional dependency and step that I found that I needed. Also add a note about needing the sysadmins to deploy to the live site.