### PR TITLE
RHEL Setup: use yum as the package manager

### DIFF
--- a/data/distro.yml
+++ b/data/distro.yml
@@ -54,7 +54,7 @@
         <h2>Install Flatpak</h2>
         <p>To install Flatpak on Red Hat Enterprise Linux 7, run the following in a terminal:</p>
         <pre><code>
-          <span class="unselectable">$</span> sudo dnf install flatpak
+          <span class="unselectable">$</span> sudo yum install flatpak
         </code></pre>
       </li>
       <!-- Apparently the GNOME Software Flatpak plugin is shipped as part of the GNOME Software package, so there’s no need to separately install it -->


### PR DESCRIPTION
Red Hat Enterprise Linux doesn't come with dnf, but uses yum.
Fixes issue #244