### PR TITLE
Update hello world url

### DIFF
--- a/source/index.html.haml
+++ b/source/index.html.haml
@@ -35,7 +35,7 @@ description: The days of chasing multiple Linux distributions are over. Standalo
         
     .row.largegap
       .col-sm-8.col-sm-offset-2.centered
-        %a.btn.btn-default.btn-xl.page-scroll{:href => "/hello-world.html"} Build your first app
+        %a.btn.btn-default.btn-xl.page-scroll{:href => "http://docs.flatpak.org/en/latest/getting-started.html"} Build your first app
         %a.btn.btn-primary.btn-xl.page-scroll{:href => "http://docs.flatpak.org/en/latest/"} Developer guide
 
 


### PR DESCRIPTION
Link directly to the Flatpak docs instead of the redirect page.