### PR TITLE
Simplify Pop!_OS instructions

### DIFF
--- a/data/distro.yml
+++ b/data/distro.yml
@@ -263,7 +263,6 @@
         <h2>Install Flatpak</h2>
         <p>The official Flatpak PPA is the recommended way to install Flatpak. To install it, run the following in a terminal:</p>
         <pre><code>
-          <span class="unselectable">$</span> sudo apt install software-properties-common --no-install-recommends
           <span class="unselectable">$</span> sudo add-apt-repository ppa:alexlarsson/flatpak
           <span class="unselectable">$</span> sudo apt update
           <span class="unselectable">$</span> sudo apt install flatpak


### PR DESCRIPTION
We don't need to install `software-properties-common` in Pop!_OS because it's included by default.