### PR TITLE
Update Installation Instructions for POP_OS

### DIFF
--- a/data/distro.yml
+++ b/data/distro.yml
@@ -276,6 +276,13 @@
           <span class="unselectable">$</span> sudo apt install flatpak
         </code></pre>
       </li>
+        <li>
+        <h2>Install Gnome Software Integration</h2>
+        <p>This plugin integrates flatpak files with the Gnome software manager in POP_OS.</p>
+        <pre><code>
+          <span class="unselectable">$</span> sudo apt install gnome-software-plugin-flatpak
+        </code></pre>
+      </li>
       <li>
         <h2>Add the Flathub repository</h2>
         <p>Flathub is the best place to get Flatpak apps. To enable it, run:</p>
@@ -286,7 +293,6 @@
       <li>
         <h2>Restart</h2>
         <p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>
-        <p>Note: graphical installation of Flatpak apps may not be possible with Pop!_OS.</p>
       </li>
     </ol>
 


### PR DESCRIPTION
Graphical installation with POP_OS 18.04 works just fine if one follows the current instructions, then installs Flatpak support (see https://packages.ubuntu.com/bionic/gnome-software-plugin-flatpak).

This PR includes the additional instructions to get it all working great.