### PR TITLE
Change the github link

### DIFF
--- a/source/about.html.haml
+++ b/source/about.html.haml
@@ -33,7 +33,7 @@ description: About Flatpak
       .col-lg-2.col-xs-4.col-lg-offset-4
         .right.toneddown GitHub project
       .col-lg-4.col-xs-8
-        =link_to "github.com/flatpak/flatpak", "https://github.com/flatpak/flatpak"
+        =link_to "github.com/flatpak/flatpak", "https://github.com/flatpak"
     .row.largegap
       .col-lg-8.col-lg-offset-2
         %p


### PR DESCRIPTION
It should point to the overall flatpak project,
not just the flatpak repo.

Closes: #291