### PR TITLE
fedora: Add docs for manually adding remote

### DIFF
--- a/data/distro.yml
+++ b/data/distro.yml
@@ -42,6 +42,11 @@
       <!-- Flatpak has been installed by default on Fedora Workstation since F25. Previous versions are past end of life, so don’t need to be mentioned. -->
       <p>Flatpak is installed by default on Fedora Workstation. To get started, all you need to do is enable Flathub, which is the best way to get Flatpak apps. Just download and install the <a class="btn btn-default" href="https://flathub.org/repo/flathub.flatpakrepo">Flathub repository file</a>.</p>
       <p>Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>
+      <p>The above links should work on the default Gnome and KDE fedora installations, but if they fail for some reason you can manually add the flathub remote by running:
+        <pre><code>
+          <span class="unselectable">$</span> flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+        </code></pre>
+      </p>
     </ol>
 
 - name: "Endless OS"


### PR DESCRIPTION
This can be used on non-gnome installations which don't have gnome-software.

Fixes https://github.com/flatpak/flatpak.github.io/issues/352