### PR TITLE
Update elementary OS instructions for 5.1+

### DIFF
--- a/data/distro.yml
+++ b/data/distro.yml
@@ -372,7 +372,8 @@
         <h2>Install Some Apps</h2>
         <!-- Curated apps in elementary OS will move to Flatpak by default, but Flathub is not included -->
         <!-- However, the Flathub remote will be added automatically when installing a Flathub app for the first time with Sideload -->
-        <p>elementary OS 5.1 and newer comes with Flatpak support out of the box. For non-curated apps, head to <a href="https://flathub.org/">Flathub</a> to install some apps! After installing one, all Flathub apps will also automatically show up in AppCenter.</p>
+        <p>elementary OS 5.1 and newer comes with Flatpak support out of the box. For non-curated apps, head to <a href="https://flathub.org/">Flathub</a> to install any app using the big "Install" button, and open the downloaded `.flatpakref` file with Sideload.</p>
+        <p>Note: After installing one app from a remote like Flathub, all other apps from that remote will also automatically show up in AppCenter.</p>
       </li>
     </ol>
 

--- a/data/distro.yml
+++ b/data/distro.yml
@@ -367,27 +367,12 @@
   logo: "elementary-os.svg"
   info: >  
     <ol class="distrotut">
+      <!-- As of elementary OS 5.1 up-to-date Flatpak is installed, AppCenter supports it ootb, and Sideload handles .flatpakref files -->
       <li>
-        <h2>Install Flatpak</h2>
-        <p>The official Flatpak PPA is the recommended way to install Flatpak. To install it, run the following in the Terminal:</p>
-        <pre><code>
-          <span class="unselectable">$</span> sudo apt install software-properties-common --no-install-recommends
-          <span class="unselectable">$</span> sudo add-apt-repository ppa:alexlarsson/flatpak
-          <span class="unselectable">$</span> sudo apt update
-          <span class="unselectable">$</span> sudo apt install flatpak
-        </code></pre>
-      </li>
-      <li>
-        <h2>Add the Flathub repository</h2>
-        <p>Flathub is the best place to get Flatpak apps. To enable it, run:</p>
-        <pre><code>
-          <span class="unselectable">$</span> flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
-        </code></pre>
-      </li>
-      <li>
-        <h2>Restart</h2>
-        <p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>
-        <p>Note: graphical installation of Flatpak apps may not be possible with elementary OS.</p>
+        <h2>Install Some Apps</h2>
+        <!-- Curated apps in elementary OS will move to Flatpak by default, but Flathub is not included -->
+        <!-- However, the Flathub remote will be added automatically when installing a Flathub app for the first time with Sideload -->
+        <p>elementary OS 5.1 and newer comes with Flatpak support out of the box. For non-curated apps, head to <a href="https://flathub.org/">Flathub</a> to install some apps! After installing one, all Flathub apps will also automatically show up in AppCenter.</p>
       </li>
     </ol>
 


### PR DESCRIPTION
As of elementary OS 5.1 up-to-date Flatpak is included in the repo and preinstalled, AppCenter supports Flatpak ootb, and the preinstalled Sideload app handles .flatpakref files. Since 5.0 users are upgraded to 5.1 and older versions are EOL, there's no need for older instructions.

Installing an app from a .flatpakref with Sideload also adds its remote, so there's no need to add it separately. 

I also tweaked the language for talking about Flathub, since curated AppCenter apps will be moving to use Flatpak by default from the elementary AppCenter remote, so users just wanting to get "Flatpak" on elementary OS will already have it. But this still directs them to Flathub for what elementary refers to as "non-curated" apps.