### PR TITLE
ChromeOS should suggest user to prevent issues

### DIFF
--- a/data/distro.yml
+++ b/data/distro.yml
@@ -79,8 +79,9 @@
         <h2>Add the Flathub repository</h2>
         <p>Flathub is the best place to get Flatpak apps. To enable it, run:</p>
         <pre><code>
-          <span class="unselectable">$</span> sudo flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+          <span class="unselectable">$</span> flatpak --user remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
         </code></pre>
+        <p>A more up to date flatpak package is available in the <a href="https://backports.debian.org/Instructions/">Debian backports repository</a>. </p>
       </li>
       <li>
         <h2>Restart</h2>
@@ -170,7 +171,7 @@
         <pre><code>
           <span class="unselectable">#</span> apt install flatpak
         </code></pre>
-        <p>For Debian Jessie and Stretch, a flatpak package is available in the <a href="https://backports.debian.org/Instructions/">official backports repository</a>.</p>
+        <p>For Debian Jessie and Stretch, a flatpak package is available in the <a href="https://backports.debian.org/Instructions/">official backports repository</a>. </p>
       </li>
       <li>
         <h2>Install the Software Flatpak plugin</h2>


### PR DESCRIPTION
ChromeOS should ideally suggest installing as a user to prevent issues writing areas that aren't encouraged. Also fixes #331 to get a more modern flatpak