### PR TITLE
Add information about graphical installation on Ubuntu 20.04

### DIFF
--- a/data/distro.yml
+++ b/data/distro.yml
@@ -21,6 +21,7 @@
         <pre><code>
           <span class="unselectable">$</span> sudo apt install gnome-software-plugin-flatpak
         </code></pre>
+        <p>Note: the Software app is distributed as a Snap since Ubuntu 20.04 and does not support graphical installation of Flatpak apps. Installing the Flatpak plugin will also install a deb version of Software and result in two Software apps being installed at the same time.</p>
       </li>
       <li>
         <h2>Add the Flathub repository</h2>


### PR DESCRIPTION
GNOME Software is available as Snap since 20.04 and has Flatpak support removed. As far as I know, there are not any plans at the moment to add this support. Installing the Flatpak plugin on 20.04 will install the deb version of GNOME Software and results in two GNOME Software applications being installed at the same time. This is confusing for the user and potentially problematic.