### PR TITLE
Update instructions for Pop_OS prior to 20.04

### DIFF
--- a/data/distro.yml
+++ b/data/distro.yml
@@ -357,7 +357,7 @@
         <h2>Add the Flathub repository</h2>
         <p>Flathub is the best place to get Flatpak apps. To enable it, run:</p>
         <pre><code>
-          <span class="unselectable">$</span> flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+          <span class="unselectable">$</span> flatpak remote-add --user --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
         </code></pre>
       </li>
       <li>


### PR DESCRIPTION
Pop_OS 20.04 uses flatpak remotes in user mode by default. In order to simplify the transition for users upgrading from 19.10 or earlier, the instructions should have users on these versions adding remotes in user-mode instead of system-mode, because otherwise the remote has to be removed and re-added in order to continue using it from Pop_Shop in 20.04.