### PR TITLE
Update Gentoo doc

### DIFF
--- a/data/distro.yml
+++ b/data/distro.yml
@@ -208,7 +208,10 @@
     <ol class="distrotut">
       <li>
         <h2>Install Flatpak</h2>
-        <p>Flatpak can be installed on Gentoo using the Flatpak overlay. See <a href="https://github.com/fosero/flatpak-overlay">the readme for instructions</a>.</p>
+        <p>To install flatpak, run:</p>
+        <pre><code>
+          <span class="unselectable">$</span> sudo emerge sys-apps/flatpak
+        </code></pre>
       </li>
       <li>
         <h2>Add the Flathub repository</h2>
@@ -220,7 +223,6 @@
       <li>
         <h2>Restart</h2>
         <p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>
-        <p>Note: graphical installation of Flatpak apps may not be possible with Gentoo.</p>
       </li>
     </ol>
 


### PR DESCRIPTION
Flatpak is now officially supported and `flatpak-overlay` has been phased out.