### PR TITLE
Fix formatting

### DIFF
--- a/data/distro.yml
+++ b/data/distro.yml
@@ -213,6 +213,7 @@
           <span class="unselectable">#</span> echo 'sys-apps/flatpak ~amd64\nacct-user/flatpak ~amd64\nacct-group/flatpak ~amd64\ndev-util/ostree ~amd64' >> /etc/portage/accept_keywords/flatpak
         </code></pre>
         <p>Then, install Flatpak:</p>
+        <pre><code>
           <span class="unselectable">#</span> emerge sys-apps/flatpak
         </code></pre>
       </li>


### PR DESCRIPTION
Fixes formatting in the Gentoo page:

![image](https://user-images.githubusercontent.com/50847364/103140505-41174100-46b5-11eb-919c-73d41a0d5e19.png)
