### PR TITLE
Add link to NixOS docs

### DIFF
--- a/data/distro.yml
+++ b/data/distro.yml
@@ -487,6 +487,7 @@
         <pre><code>
           <span class="unselectable">$</span> sudo nixos-rebuild switch
         </code></pre>
+        <p>For more details see the <a href="https://nixos.org/manual/nixos/stable/index.html#module-services-flatpak">NixOS documentation</a>.</p>
       </li>
       <li>
         <h2>Add the Flathub repository</h2>


### PR DESCRIPTION
Users might have to add config around `xdg.portal`, 
tbh I don't know if that's always the case so best to link to the official docs just in case.