### PR TITLE
Use mini_racer instead of therubyracer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,4 +28,4 @@ gem "middleman-sprockets", "~> 3.1.2"
 
 #Ubuntu specific gems
 gem "rb-inotify"
-gem "therubyracer"
+gem "mini_racer"


### PR DESCRIPTION
Attempt to fix #468.

therubyracer gem does not seem to be maintained anymore and is incompatible with Ruby 3.0.