### PR TITLE
Fix link to Matrix channel

### DIFF
--- a/source/about.html.haml
+++ b/source/about.html.haml
@@ -31,7 +31,7 @@ description: About Flatpak
       .col-lg-2.col-xs-4.col-lg-offset-4
         .right.toneddown Matrix
       .col-lg-4.col-xs-8
-        =link_to "#flatpak on Matrix.org", "https://matrix.to/#flatpak:matrix.org"
+        =link_to "#flatpak on Matrix.org", "https://matrix.to/#/#flatpak:matrix.org"
     .row
       .col-lg-2.col-xs-4.col-lg-offset-4
         .right.toneddown GitHub


### PR DESCRIPTION
https://matrix.to/#flatpak:matrix.org says:

> The link you have entered is not valid. If you like, you can return to the home page.
> 
> Did you mean any of the following?
> - The user @flatpak:matrix.org
> - The room alias #flatpak:matrix.org
> - The room !flatpak:matrix.org

The room alias is the one we want.