### PR TITLE
Fix fedora remote-add flathub instructions

### DIFF
--- a/data/distro.yml
+++ b/data/distro.yml
@@ -45,7 +45,7 @@
       <p>Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>
       <p>The above links should work on the default GNOME and KDE Fedora installations, but if they fail for some reason you can manually add the Flathub remote by running:
         <pre><code>
-          <span class="unselectable">$</span> flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+          <span class="unselectable">$</span> flatpak --user remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
         </code></pre>
       </p>
     </ol>


### PR DESCRIPTION
When I pasted the below command into a terminal on "Fedora release 34 (Thirty Four)" I got an error (see below). Adding --user fixed the error. Note: this is *not* an official spin of Fedora Workstation, but qubes-template-fedora-34-minimal shipped by [QubesOS](https://www.qubes-os.org/). It is possible that the command would have worked fine on Fedora Workstation.
```
$ flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
error: Creating repo: mkdirat: Permission denied.
```

# Edit: I have found a fix
In case anyone has ran into the same issues the fix is to run:
```sh
sudo flatpak repair
```