### PR TITLE
Fix layout for Chrome OS setup guide

### DIFF
--- a/data/distro.yml
+++ b/data/distro.yml
@@ -84,12 +84,9 @@
       </li>
       <li>
         <h2>Enable nested containers</h2>
-        <ul>
-          <li>Close the Linux environment, if it is already active</li>
-          <li>Open a Chrome browser</li>
-          <li>Press Ctrl-Alt-T</li>
-        </ul>
-        <p>In the <code>crosh</code> tab that will open, use these commands to enable nested containers:</p>
+        <p>2.1- Close the Linux environment, if it is already active.</p>
+        <p>2.2- Open a Chrome browser, then press Ctrl-Alt-T</p>
+        <p>2.3- In the <code>crosh</code> tab that will open, use these commands to enable nested containers:</p>
         <pre><code>
           <span class="unselectable">$</span> vmc start termina
           <span class="unselectable">$</span> lxc config set penguin security.nesting true


### PR DESCRIPTION
The layout for the Chrome OS Setup guide page [https://flatpak.org/setup/Chrome%20OS](https://flatpak.org/setup/Chrome%20OS) had a step, which had "substeps" nested inside another list. 
This is what it currently looks like (on both Firefox 99.0.1 64-bit on Fedora 35 Workstation):

[![Screenshot-20220425-135632.png](https://i.postimg.cc/Y9hG5Jsq/Screenshot-20220425-135632.png)](https://postimg.cc/MMJpRrwh)

And this is how it looks like on Chromium 100.0.4896.127 64-bit:
[![Screenshot-20220425-141552.png](https://i.postimg.cc/R0WhZ2c3/Screenshot-20220425-141552.png)](https://postimg.cc/Z9h4f7sZ)

I tried keeping the steps 3 through 5 as a sublist with the big circles, but it didn't look well / didn't align properly. I have thought of this solution in the meantime

[![Screenshot-20220425-140223.png](https://i.postimg.cc/QxTf1zS7/Screenshot-20220425-140223.png)](https://postimg.cc/56f5Mnh9)

Let me know what you think
