### PR TITLE
Fix distro url with special chars

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -17,7 +17,7 @@ page '/*.txt', layout: false
 #  which_fake_page: "Rendering a fake page with a local variable" }
 
 data.distro.each do |i|
-  proxy "/setup/#{i.name}.html", "/distro-template.html", :locals => { :name => i.name, :logo => i.logo, :info => i.info }, :ignore => true
+  proxy "/setup/#{i.slug ? i.slug : i.name}.html", "/distro-template.html", :locals => { :name => i.name, :logo => i.logo, :info => i.info, :slug => i.slug }, :ignore => true
 end
 
 # General configuration

--- a/data/distro.yml
+++ b/data/distro.yml
@@ -676,6 +676,7 @@
     </ol>
 
 - name: "Pisi GNU/Linux"
+  slug: "Pisi GNU Linux"
   logo: "pisi.svg"
   logo_dark: "pisi-dark.svg"
   info: >
@@ -737,7 +738,7 @@
     <ol class="distrotut">
         <h2>Enable Flatpak through the Software Manager</h2>
         <p>Flatpak support is built in by default from KDE neon 19 and later. To activate the <a href="https://flathub.org/">Flathub</a> repository in Discover, just follow the instructions below:</p>
-        <p>Open Discover and click on Settings (lower left corner).</p2> 
+        <p>Open Discover and click on Settings (lower left corner).</p2>
         <p>Check that in the Flatpak section the box is checked.</p>
         <p>Note: with this Flathub app search will be integrated in Discover, if you want to limit the app search to Flathub you can mark Flatpak as default by clicking on the star.</p>
     </ol>

--- a/source/setup.html.haml
+++ b/source/setup.html.haml
@@ -10,11 +10,11 @@ description: Quick Setup
         %h1.centered Quick Setup
         %p.centered
           Select your distro to get set up.
-          
+
     .row
       .distrogrid.col-lg-8.col-lg-offset-2
         - data.distro.each do |i|
-          %a{:href => "/setup/#{i.name}"}
+          %a{:href => "/setup/#{i.slug ? i.slug : i.name}"}
             %picture
               %source{ :srcset => i.logo_dark ? "/img/distro/#{i.logo_dark}" : "/img/distro/#{i.logo}" , :media => "(prefers-color-scheme: dark)"}
               %img{ :src => "/img/distro/#{i.logo}", :alt => "#{i.name}", :title => "#{i.name}"}

--- a/source/setup.html.haml
+++ b/source/setup.html.haml
@@ -16,5 +16,5 @@ description: Quick Setup
         - data.distro.each do |i|
           %a{:href => "/setup/#{i.slug ? i.slug : i.name}"}
             %picture
-              %source{ :srcset => i.logo_dark ? "/img/distro/#{i.logo_dark}" : "/img/distro/#{i.logo}" , :media => "(prefers-color-scheme: dark)"}
+              %source{ :srcset => "/img/distro/#{i.logo_dark ? i.logo_dark : i.logo}" , :media => "(prefers-color-scheme: dark)"}
               %img{ :src => "/img/distro/#{i.logo}", :alt => "#{i.name}", :title => "#{i.name}"}


### PR DESCRIPTION
This should finally fix the link to Pisi Linux