### PR TITLE
Workaround Flathub remote being disabled on Fedora 36 by default

### DIFF
--- a/data/distro.yml
+++ b/data/distro.yml
@@ -48,6 +48,11 @@
           <span class="unselectable">$</span> flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
         </code></pre>
       </p>
+      <p>Since Fedora 36 Flathub is explicitly disabled so it needs to be manually enabled with this command:
+        <pre><code>
+          <span class="unselectable">$</span> flatpak remote-modify --enable flathub
+        </code></pre>
+      </p>
     </ol>
 
 - name: "Manjaro"

--- a/data/distro.yml
+++ b/data/distro.yml
@@ -48,7 +48,7 @@
           <span class="unselectable">$</span> flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
         </code></pre>
       </p>
-      <p>Since Fedora 36 Flathub is explicitly disabled so it needs to be manually enabled with this command:
+      <p>Flathub is explicitly disabled since Fedora 36 and needs to be manually enabled with this command:
         <pre><code>
           <span class="unselectable">$</span> flatpak remote-modify --enable flathub
         </code></pre>

--- a/data/distro.yml
+++ b/data/distro.yml
@@ -48,9 +48,10 @@
           <span class="unselectable">$</span> flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
         </code></pre>
       </p>
-      <p>Flathub is explicitly disabled since Fedora 36 and needs to be manually enabled with this command:
+      <p>Fedora has a "filtered" Flathub remote added but disabled. It needs to be removed and added again to get the full repository when you enable it.
         <pre><code>
-          <span class="unselectable">$</span> flatpak remote-modify --enable flathub
+          <span class="unselectable">$</span> flatpak remote-delete flathub 
+          <span class="unselectable">$</span> flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
         </code></pre>
       </p>
     </ol>


### PR DESCRIPTION
Starting with Fedora 36 Flathub is explicitly disabled.

I'm not sure about my formatting as Github doesn't allow me to test how my changes will look. I just copied the formatting above it for enabling the repo.