### PR TITLE
ci (workflows): bump actions version; fix node deprecation warning

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - uses: ruby/setup-ruby@v1
       with:
@@ -30,7 +30,7 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
-    - uses: docker/build-push-action@v3
+    - uses: docker/build-push-action@v4
       with:
         file: Dockerfile
         push: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Setup ruby
       uses: ruby/setup-ruby@v1


### PR DESCRIPTION
## Changes

- Bump the `actions/checkout` version from `v2` (Node 12) to `v3` (Node 16). 
- Bump the `docker/build-push-action` version from `v3` to `v4`.

This PR fixes the Node 12 deprecation warning displayed under Annotations in Actions runs during `actions/checkout`, by bumping it to `v3` (Node 16).