### PR TITLE
Don't use h1 in instructions

### DIFF
--- a/data/distro.yml
+++ b/data/distro.yml
@@ -70,7 +70,7 @@
 - name: "Endless OS"
   logo: "endless.svg"
   info: >
-    <h1>Flatpak support is built into Endless OS 3.0.0 and newer—no setup required!</h1>
+    <h2>Flatpak support is built into Endless OS 3.0.0 and newer—no setup required!</h2>
     <p>If you are using an older version, <a href="https://community.endlessos.com/t/upgrade-from-endless-os-2-x-to-endless-os-3/967">upgrade to Endless OS 3</a>.</p>
 
 - name: "Chrome OS"
@@ -143,7 +143,7 @@
 - name: "Linux Mint"
   logo: "mint.svg"
   info: >
-    <h1>Flatpak support is built into Linux Mint 18.3 and newer—no setup required!</h1>
+    <h2>Flatpak support is built into Linux Mint 18.3 and newer—no setup required!</h2>
     <p>If you are using an older version, <a href="https://blog.linuxmint.com/?p=3462">upgrade to Linux Mint 18.3</a>.</p>
 
 - name: "openSUSE"
@@ -422,7 +422,7 @@
 - name: "Pop!_OS"
   logo: "pop-os.svg"
   info: >
-    <h1>Pop!_OS 20.04 has Flatpak installed and Flathub configured by default. The Pop!_Shop can be used to install flatpaks.</h1>
+    <h2>Pop!_OS 20.04 has Flatpak installed and Flathub configured by default. The Pop!_Shop can be used to install flatpaks.</h2>
     <p>For older versions of Pop!_OS, see the instructions below.</p>
     <ol class="distrotut">
       <li>


### PR DESCRIPTION
This leads to two h1 back to back, is a bit
weird and search engines recommend not to do.

So this changes it to h2 at least