### PR TITLE
distro: Update Debian information

### DIFF
--- a/data/distro.yml
+++ b/data/distro.yml
@@ -188,7 +188,6 @@
         <pre><code>
           <span class="unselectable">#</span> apt install flatpak
         </code></pre>
-        <p>For Debian Jessie and Stretch, a flatpak package is available in the <a href="https://backports.debian.org/Instructions/">official backports repository</a>. </p>
       </li>
       <li>
         <h2>Install the Software Flatpak plugin</h2>


### PR DESCRIPTION
Remove information about Debian Jessie and Stretch backports. Both are no longer [supported](https://wiki.debian.org/LTS).