### PR TITLE
Update distro.yml Alpine Linux section

### DIFF
--- a/data/distro.yml
+++ b/data/distro.yml
@@ -359,7 +359,17 @@
         <h2>Install Flatpak</h2>
         <p>Flatpak can be installed from the community repository. Run the following in a terminal:</p>
         <pre><code>
-          <span class="unselectable">$</span> sudo apk add flatpak
+          <span class="unselectable">$</span> doas apk add flatpak
+        </code></pre>
+      </li>
+      <h2>Install the Software Flatpak plugin</h2>
+        <p>You can install the Flatpak plugin for either the GNOME Software (since v3.13) or KDE Discover (since v3.11), making it possible to install apps without needing the command line. To install, for GNOME Software run:</p>
+        <pre><code>
+          <span class="unselectable">$</span> doas apk add gnome-software-plugin-flatpak
+        </code></pre>
+        <p>And for KDE Discover, run this instead:</p>
+        <pre><code>
+          <span class="unselectable">$</span> doas apk add discover-backend-flatpak
         </code></pre>
       </li>
       <li>
@@ -371,8 +381,7 @@
       </li>
       <li>
         <h2>Restart</h2>
-        <p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>
-        <p>Note: graphical installation of Flatpak apps may not be possible with Alpine.</p>
+        <p>To complete the setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>
       </li>
     </ol>
 


### PR DESCRIPTION
I've changed sudo to doas, as that is the primary method to elevate privileges in Alpine Linux and added a section about adding the plugins for GNOME Software & KDE Discover (with a brief mention when they first appeared in community repo).

Also removed the line about not being about to not being about the graphically install flatpak apps in Alpine, because of the added section.

I've styled it similarly to the Ubuntu section, but I haven't run the changed on a test server tbh.

This should fix the closed bug #1736