### PR TITLE
Update history

### DIFF
--- a/source/about.html.haml
+++ b/source/about.html.haml
@@ -132,7 +132,7 @@ description: About Flatpak
             1Password adopts Flatpak to publish on Linux
           .date Febuary 2022
           .description
-            Valve releases the Steam Deck a handheld video game console includes out of the box Flatpak an Flathub integration
+            Valve releases the Steam Deck; a handheld video game console with out of the box Flatpak and Flathub integration
           .date Febuary 2022
           .description
             OBS Studio adopts Flatpak to publish on Linux
@@ -142,8 +142,7 @@ description: About Flatpak
           .date April 2023
           .description
             Purism introduces Flatpak and the PureOS Flatpak repository;
-            = succeed "." do
-            =link_to "announcement", "https://puri.sm/posts/introducing-flatpaks-on-pureos/"#
+            =link_to "announcement", "https://puri.sm/posts/introducing-flatpaks-on-pureos/"
           .date April 2023
           .description
             Valve adopts portals for the popular Steam application

--- a/source/about.html.haml
+++ b/source/about.html.haml
@@ -85,6 +85,9 @@ description: About Flatpak
           .date June 2016
           .description
             Work on desktop portals security framework begins
+          .date June 2016
+          .description
+            Libreoffice is the first major application to adopt Flatpak for publishing on Linux
           .date July 2016
           .description
             GTK+ 3.21.4 released with initial support for the portals framework
@@ -118,3 +121,32 @@ description: About Flatpak
           .date December 2019
           .description
             elementary OS 5.1 Hera released, includes out of the box Flatpak integration
+          .date April 2020
+          .description
+            Mozilla adopts Flatpak to publish Firefox on Linux
+          .date April 2020
+          .description
+            System76 releases Pop!_OS 20.04, includes out of the box Flatpak integration
+          .date October 2021
+          .description
+            1Password adopts Flatpak to publish on Linux
+          .date Febuary 2022
+          .description
+            Valve releases the Steam Deck a handheld video game console includes out of the box Flatpak an Flathub integration
+          .date Febuary 2022
+          .description
+            OBS Studio adopts Flatpak to publish on Linux
+          .date May 2022
+          .description
+            Red Hat Enterprise Linux Workstation 9 released, includes out of the box Flatpak integration
+          .date April 2023
+          .description
+            Purism introduces Flatpak and the PureOS Flatpak repository;
+            = succeed "." do
+            =link_to "announcement", "https://puri.sm/posts/introducing-flatpaks-on-pureos/"#
+          .date April 2023
+          .description
+            Valve adopts portals for the popular Steam application
+          .date May 2023
+          .description
+            Flathub offers more than 2000 apps and celebrates 1B total downloads


### PR DESCRIPTION
Fixes https://github.com/flatpak/flatpak.github.io/issues/557

Not tested. I would love to but I gave up after

> sonny@porygon ~/P/f/flatpak.github.io (update-history)> bundle exec middleman server
Calling `DidYouMean::SPELL_CHECKERS.merge!(error_name => spell_checker)' has been deprecated. Please call `DidYouMean.correct_error(error_name, spell_checker)' instead.
bundler: failed to load command: middleman (/home/sonny/Projects/flathub/flatpak.github.io/vendor/bundle/ruby/3.2.0/bin/middleman)
/home/sonny/Projects/flathub/flatpak.github.io/vendor/bundle/ruby/3.2.0/gems/middleman-deploy-2.0.0.pre.alpha/lib/middleman-deploy/methods/ftp.rb:1:in `require': cannot load such file -- net/ftp (LoadError)


See https://floss.social/@sonny/110578704543157206
The following are Fedora Flatpak updates as shared by @TheEvilSkeleton 


* Fedora Flatpaks (Fedora's Flatpak remote) was launched in December 2018 -- https://blog.fishsoup.net/2018/12/04/flatpaks-in-fedora-now-live/
* Red Hat's runtime launched in December 2020 -- https://developers.redhat.com/blog/2020/08/12/introducing-the-red-hat-flatpak-runtime-for-desktop-containers
* Fedora 35's "third party" option shipped a filtered version of Flathub -- https://fedoraproject.org/wiki/Changes/Filtered_Flathub_Applications
* Fedora 38's "third party" option expanded and started shipping an unfiltered version of Flathub -- https://fedoraproject.org/wiki/Changes/UnfilteredFlathub

I didn't include them because it's too granular and Fedora is an obvious adopter of Flatpak I guess. Maybe we could at least include the date at which Flatpak was installed by default?