### PR TITLE
feat: add copy button to terminal commands

### DIFF
--- a/data/distro.yml
+++ b/data/distro.yml
@@ -5,30 +5,26 @@
       <li>
         <h2>Install Flatpak</h2>
         <p>To install Flatpak on Ubuntu 18.10 (Cosmic Cuttlefish) or later, simply run:</p>
-        <pre><code>
-          <span class="unselectable">$</span> sudo apt install flatpak
-        </code></pre>
+        <terminal-command>sudo apt install flatpak</terminal-command>
         <p>With older Ubuntu versions, the official Flatpak PPA is the recommended way to install Flatpak. To install it, run the following in a terminal:</p>
-        <pre><code>
-          <span class="unselectable">$</span> sudo add-apt-repository ppa:flatpak/stable
-          <span class="unselectable">$</span> sudo apt update
-          <span class="unselectable">$</span> sudo apt install flatpak
-        </code></pre>
+        <terminal-command>
+          sudo add-apt-repository ppa:flatpak/stable
+          sudo apt update
+          sudo apt install flatpak
+        </terminal-command>
       </li>
       <li>
         <h2>Install the Software Flatpak plugin</h2>
         <p>The Flatpak plugin for the Software app makes it possible to install apps without needing the command line. To install, run:</p>
-        <pre><code>
-          <span class="unselectable">$</span> sudo apt install gnome-software-plugin-flatpak
-        </code></pre>
+        <terminal-command>sudo apt install gnome-software-plugin-flatpak</terminal-command>
         <p>Note: the Software app is distributed as a Snap since Ubuntu 20.04 and does not support graphical installation of Flatpak apps. Installing the Flatpak plugin will also install a deb version of Software and result in two Software apps being installed at the same time.</p>
       </li>
       <li>
         <h2>Add the Flathub repository</h2>
         <p>Flathub is the best place to get Flatpak apps. To enable it, run:</p>
-        <pre><code>
-          <span class="unselectable">$</span> flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
-        </code></pre>
+        <terminal-command>
+          flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+        </terminal-command>
       </li>
       <li>
         <h2>Restart</h2>
@@ -44,9 +40,9 @@
       <p>Flatpak is installed by default on Fedora Workstation, Fedora Silverblue, and Fedora Kinoite. To get started, all you need to do is enable Flathub, which is the best way to get Flatpak apps. Just download and install the <a class="btn btn-default" href="https://dl.flathub.org/repo/flathub.flatpakrepo">Flathub repository file</a>.</p>
       <p>Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>
       <p>The above links should work on the default GNOME and KDE Fedora installations, but if they fail for some reason you can manually add the Flathub remote by running:
-        <pre><code>
-          <span class="unselectable">$</span> flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
-        </code></pre>
+        <terminal-command>
+          flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+        </terminal-command>
       </p>
     </ol>
 
@@ -89,17 +85,17 @@
       <li>
         <h2>Install Flatpak</h2>
         <p>To install Flatpak, run the following in the terminal:</p>
-        <pre><code>
-          <span class="unselectable">$</span> sudo apt install flatpak
-        </code></pre>
+        <terminal-command>
+          sudo apt install flatpak
+        </terminal-command>
         <p>A more up to date flatpak package is available in the <a href="https://backports.debian.org/Instructions/">Debian backports repository</a>. </p>
       </li>
       <li>
         <h2>Add the Flathub repository</h2>
         <p>Flathub is the best place to get Flatpak apps. To enable it, run:</p>
-        <pre><code>
-          <span class="unselectable">$</span> flatpak --user remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
-        </code></pre>
+        <terminal-command>
+          flatpak --user remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+        </terminal-command>
       </li>
       <li>
         <h2>Restart</h2>
@@ -115,15 +111,13 @@
       <p>Flatpak is installed by default on Red Hat Enterprise Linux Workstation 9 and newer. To get started, all you need to do is enable Flathub, which is the best way to get Flatpak apps. Just download and install the <a class="btn btn-default" href="https://dl.flathub.org/repo/flathub.flatpakrepo">Flathub repository file</a>.</p>
       <p>To install Flatpak on Red Hat Enterprise Linux Workstation 8 or older, run the following in a terminal:
         <!-- Apparently the GNOME Software Flatpak plugin is shipped as part of the GNOME Software package, so there’s no need to separately install it -->
-        <pre><code>
-          <span class="unselectable">$</span> sudo yum install flatpak
-        </code></pre>
+        <terminal-command>sudo yum install flatpak</terminal-command>
       </p>
       <p>Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>
       <p>The above links should work on the default Red Hat Enterprise Linux Workstation 9 installation, but if they fail for some reason you can manually add the Flathub remote by running:
-        <pre><code>
-          <span class="unselectable">$</span> flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
-        </code></pre>
+        <terminal-command>
+          flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+        </terminal-command>
       </p>
     </ol>
 
@@ -142,16 +136,14 @@
         <p>Flatpak is available in the default repositories of all currently maintained openSUSE Leap and openSUSE Tumbleweed versions.</p>
         <p>If you prefer a graphical installation, you can install Flatpak using a "1-click installer" from <a href="https://software.opensuse.org/package/flatpak">software.opensuse.org</a>. If your distribution version is not shown by default, click <em>Show flatpak for other distributions</em> first and then select from the list.</p>
         <p>Alternatively, install Flatpak from the command line using Zypper:</p>
-        <pre><code>
-          <span class="unselectable">$</span> sudo zypper install flatpak
-        </code></pre>
+        <terminal-command>sudo zypper install flatpak</terminal-command>
       </li>
       <li>
         <h2>Add the Flathub repository</h2>
         <p>Flathub is the best place to get Flatpak apps. To enable it, run:</p>
-        <pre><code>
-          <span class="unselectable">$</span> flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
-        </code></pre>
+        <terminal-command>
+          flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+        </terminal-command>
       </li>
       <li>
         <h2>Restart</h2>
@@ -166,9 +158,7 @@
       <li>
         <h2>Install Flatpak</h2>
         <p>To install Flatpak, run the following in a terminal:</p>
-        <pre><code>
-          <span class="unselectable">$</span> sudo pacman -S flatpak
-        </code></pre>
+        <terminal-command>sudo pacman -S flatpak</terminal-command>
       </li>
       <!-- On arch, Flathub is added when the Flatpak package is installed. -->
       <!-- Apparently the GNOME Software Flatpak plugin is shipped as part of the GNOME Software package, so there's no need to separately install it -->
@@ -185,27 +175,21 @@
       <li>
         <h2>Install Flatpak</h2>
         <p>A flatpak package is available in Debian Buster and newer. To install it, run the following as root:</p>
-        <pre><code>
-          <span class="unselectable">#</span> apt install flatpak
-        </code></pre>
+        <terminal-command>apt install flatpak</terminal-command>
       </li>
       <li>
         <h2>Install the Software Flatpak plugin</h2>
         <p>If you are running GNOME, it is also a good idea to install the Flatpak plugin for GNOME Software. To do this, run:</p>
-        <pre><code>
-          <span class="unselectable">#</span> apt install gnome-software-plugin-flatpak
-        </code></pre>
+        <terminal-command>apt install gnome-software-plugin-flatpak</terminal-command>
         <p>If you are running KDE Plasma, you can install the Flatpak plugin for KDE Discover instead:</p>
-        <pre><code>
-          <span class="unselectable">#</span> apt install plasma-discover-backend-flatpak
-        </code></pre>
+        <terminal-command>apt install plasma-discover-backend-flatpak</terminal-command>
       </li>
       <li>
         <h2>Add the Flathub repository</h2>
         <p>Flathub is the best place to get Flatpak apps. To enable it, run:</p>
-        <pre><code>
-          <span class="unselectable">#</span> flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
-        </code></pre>
+        <terminal-command>
+          flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+        </terminal-command>
       </li>
       <li>
         <h2>Restart</h2>
@@ -220,16 +204,14 @@
       <li>
         <h2>Install Flatpak</h2>
         <p>Flatpak is installed by default on Rocky Linux 8 and newer, when installed with a software selection that includes GNOME (Server with GUI, Workstation). If you are using such a system, you may skip this step. To install Flatpak on Rocky Linux, run the following in a terminal:</p>
-        <pre><code>
-          <span class="unselectable">$</span> sudo dnf install flatpak
-        </code></pre>
+        <terminal-command>sudo dnf install flatpak</terminal-command>
       </li>
       <li>
         <h2>Add the Flathub repository</h2>
         <p>Flathub is the best way to get Flatpak apps. To enable it, download and install the <a class="btn btn-default" href="https://dl.flathub.org/repo/flathub.flatpakrepo">Flathub repository file</a>, or run the following in a terminal:</p>
-        <pre><code>
-          <span class="unselectable">$</span> flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
-        </code></pre>
+        <terminal-command>
+          flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+        </terminal-command>
       <li>
         <h2>Restart</h2>
         <p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>
@@ -267,20 +249,18 @@
       <li>
         <h2>Install Flatpak</h2>
         <p>To install Flatpak, enable the ~amd64 keyword for sys-apps/flatpak, acct-user/flatpak and acct-group/flatpak:</p>
-        <pre><code>
-          <span class="unselectable">#</span> echo -e 'sys-apps/flatpak ~amd64\nacct-user/flatpak ~amd64\nacct-group/flatpak ~amd64\ndev-util/ostree ~amd64' >> /etc/portage/package.accept_keywords/flatpak
-        </code></pre>
+        <terminal-command>
+          echo -e 'sys-apps/flatpak ~amd64\nacct-user/flatpak ~amd64\nacct-group/flatpak ~amd64\ndev-util/ostree ~amd64' >> /etc/portage/package.accept_keywords/flatpak
+        </terminal-commande>
         <p>Then, install Flatpak:</p>
-        <pre><code>
-          <span class="unselectable">#</span> emerge sys-apps/flatpak
-        </code></pre>
+        <terminal-command>emerge sys-apps/flatpak</terminal-command>
       </li>
       <li>
         <h2>Add the Flathub repository</h2>
         <p>Flathub is the best place to get Flatpak apps. To enable it, run:</p>
-        <pre><code>
-          <span class="unselectable">$</span> flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
-        </code></pre>
+        <terminal-command>
+          flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+        </terminal-command>
       </li>
       <li>
         <h2>Restart</h2>
@@ -296,33 +276,31 @@
       <li>
         <h2>Install Flatpak</h2>
         <p>To install Flatpak on Kubuntu 18.10 (Cosmic Cuttlefish), simply run:</p>
-        <pre><code>
-          <span class="unselectable">$</span> sudo apt install flatpak
-        </code></pre>
+        <terminal-command>sudo apt install flatpak</terminal-command>
         <p>With older Kubuntu versions, the official Flatpak PPA is the recommended way to install Flatpak. To install it, run the following in a terminal:</p>
-        <pre><code>
-          <span class="unselectable">$</span> sudo add-apt-repository ppa:alexlarsson/flatpak
-          <span class="unselectable">$</span> sudo apt update
-          <span class="unselectable">$</span> sudo apt install flatpak
-        </code></pre>
+        <terminal-command>
+          sudo add-apt-repository ppa:alexlarsson/flatpak
+          sudo apt update
+          sudo apt install flatpak
+        </terminal-command>
       </li>
       <li>
         <h2>Install the Discover Flatpak backend</h2>
         <p>The Flatpak plugin for the Software app makes it possible to install apps without needing the command line (available on Kubuntu 18.04 and newer). To install on 18.04, run:</p>
-        <pre><code>
-          <span class="unselectable">$</span> sudo apt install plasma-discover-flatpak-backend
-        </code></pre>
+        <terminal-command>
+          sudo apt install plasma-discover-flatpak-backend
+        </terminal-command>
         <p>On Kubuntu 20.04 or later, you should run this instead:</p>
-        <pre><code>
-          <span class="unselectable">$</span> sudo apt install plasma-discover-backend-flatpak
-        </code></pre>
+        <terminal-command>
+          sudo apt install plasma-discover-backend-flatpak
+        </terminal-command>
       </li>
       <li>
         <h2>Add the Flathub repository</h2>
         <p>Flathub is the best place to get Flatpak apps. To enable it, run:</p>
-        <pre><code>
-          <span class="unselectable">$</span> flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
-        </code></pre>
+        <terminal-command>
+          flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+        </terminal-command>
       </li>
       <li>
         <h2>Restart</h2>
@@ -337,16 +315,16 @@
       <li>
         <h2>Install Flatpak</h2>
         <p>To install Flatpak, run the following in a terminal:</p>
-        <pre><code>
-          <span class="unselectable">$</span> sudo eopkg install flatpak xdg-desktop-portal-gtk
-        </code></pre>
+        <terminal-command>
+          sudo eopkg install flatpak xdg-desktop-portal-gtk
+        </terminal-command>
       </li>
       <li>
         <h2>Add the Flathub repository</h2>
         <p>Flathub is the best place to get Flatpak apps. To enable it, run:</p>
-        <pre><code>
-          <span class="unselectable">$</span> flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
-        </code></pre>
+        <terminal-command>
+          flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+        </terminal-command>
       </li>
       <li>
         <h2>Restart</h2>
@@ -362,27 +340,27 @@
       <li>
         <h2>Install Flatpak</h2>
         <p>Flatpak can be installed from the community repository. Run the following in a terminal:</p>
-        <pre><code>
-          <span class="unselectable">$</span> doas apk add flatpak
-        </code></pre>
+        <terminal-command>
+          doas apk add flatpak
+        </terminal-command>
       </li>
       <li>
         <h2>Install the Software Flatpak plugin</h2>
         <p>You can install the Flatpak plugin for either the GNOME Software (since v3.13) or KDE Discover (since v3.11), making it possible to install apps without needing the command line. To install, for GNOME Software run:</p>
-        <pre><code>
-          <span class="unselectable">$</span> doas apk add gnome-software-plugin-flatpak
-        </code></pre>
+        <terminal-command>
+          doas apk add gnome-software-plugin-flatpak
+        </terminal-command>
         <p>And for KDE Discover, run this instead:</p>
-        <pre><code>
-          <span class="unselectable">$</span> doas apk add discover-backend-flatpak
-        </code></pre>
+        <terminal-command>
+          doas apk add discover-backend-flatpak
+        </terminal-command>
       </li>
       <li>
         <h2>Add the Flathub repository</h2>
         <p>Flathub is the best place to get Flatpak apps. To enable it, run:</p>
-        <pre><code>
-          <span class="unselectable">$</span> flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
-        </code></pre>
+        <terminal-command>
+          flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+        </terminal-command>
       </li>
       <li>
         <h2>Restart</h2>
@@ -397,20 +375,20 @@
       <li>
         <h2>Install Flatpak</h2>
         <p>A flatpak package is available for Mageia 6 and newer. To install with DNF, run the following as root:</p>
-        <pre><code>
-          <span class="unselectable">#</span> dnf install flatpak
-        </code></pre>
+        <terminal-command>
+          dnf install flatpak
+        </terminal-command>
         <p>Or, to install with <code>urpmi</code>, run:</p>
-        <pre><code>
-          <span class="unselectable">#</span> urpmi flatpak
-        </code></pre>
+        <terminal-command>
+          urpmi flatpak
+        </terminal-command>
       </li>
       <li>
         <h2>Add the Flathub repository</h2>
         <p>Flathub is the best place to get Flatpak apps. To enable it, run:</p>
-        <pre><code>
-          <span class="unselectable">$</span> flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
-        </code></pre>
+        <terminal-command>
+          flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+        </terminal-command>
       </li>
       <li>
         <h2>Restart</h2>
@@ -428,16 +406,16 @@
       <li>
         <h2>Install Flatpak</h2>
         <p>To install Flatpak on Pop!_OS 19.10 and earlier, simply run:</p>
-       <pre><code>
-          <span class="unselectable">$</span> sudo apt install flatpak
-        </code></pre>
+       <terminal-command>
+          sudo apt install flatpak
+        </terminal-command>
       </li>
       <li>
         <h2>Add the Flathub repository</h2>
         <p>Flathub is the best place to get Flatpak apps. To enable it, run:</p>
-        <pre><code>
-          <span class="unselectable">$</span> flatpak remote-add --user --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
-        </code></pre>
+        <terminal-command>
+          flatpak remote-add --user --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+        </terminal-command>
       </li>
       <li>
         <h2>Restart</h2>
@@ -468,16 +446,16 @@
       <li>
         <h2>Install Flatpak</h2>
         <p>A flatpak package is available in Raspberry Pi OS (previously called Raspbian) Stretch and newer. To install it, run the following as root:</p>
-        <pre><code>
-          <span class="unselectable">#</span> apt install flatpak
-        </code></pre>
+        <terminal-command>
+          apt install flatpak
+        </terminal-command>
       </li>
       <li>
         <h2>Add the Flathub repository</h2>
         <p>Flathub is the best place to get Flatpak apps. To enable it, run:</p>
-        <pre><code>
-          <span class="unselectable">#</span> flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
-        </code></pre>
+        <terminal-command>
+          flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+        </terminal-command>
         <p><b>Important note:</b> As of March 2021, Raspberry Pi computers still ship with the 32-bit version of Raspberry Pi OS. However Flathub started phasing out support for that architecture. If you consider Flathub as an important source of applications, it is recommended to use Raspberry Pi OS 64-bit as newer applications are more likely to be available for that platform.</p>
       </li>
       <li>
@@ -492,9 +470,9 @@
   info: >
     <ol class="distrotut">
       <p>Flatpak is installed and Flathub repository is pre-configured by default on Clear Linux when installing the desktop bundle.</p>
-      <pre><code>
-        <span class="unselectable">$</span> sudo swupd bundle-add desktop
-      </code></pre>
+      <terminal-command>
+        sudo swupd bundle-add desktop
+      </terminal-command>
       <p>Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>
     </ol>
 
@@ -506,16 +484,16 @@
       <li>
         <h2>Install Flatpak</h2>
         <p>To install Flatpak, run the following:</p>
-        <pre><code>
-          <span class="unselectable">$</span> sudo xbps-install -S flatpak
-        </code></pre>
+        <terminal-command>
+          sudo xbps-install -S flatpak
+        </terminal-command>
       </li>
       <li>
         <h2>Add the Flathub repository</h2>
         <p>Flathub is the best place to get Flatpak apps. To enable it, run:</p>
-        <pre><code>
-          <span class="unselectable">$</span> flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
-        </code></pre>
+        <terminal-command>
+          flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+        </terminal-command>
       </li>
       <li>
         <h2>Restart</h2>
@@ -533,21 +511,21 @@
           To install Flatpak, set NixOS option <code>services.flatpak.enable</code> to <code>true</code>
           by putting the following into your <code>/etc/nixos/configuration.nix</code>:
         </p>
-        <pre><code>
+        <terminal-command>
           services.flatpak.enable = true;
-        </code></pre>
+        </terminal-command>
         <p>Then, rebuild and switch to the new configuration with:</p>
-        <pre><code>
-          <span class="unselectable">$</span> sudo nixos-rebuild switch
-        </code></pre>
+        <terminal-command>
+          sudo nixos-rebuild switch
+        </terminal-command>
         <p>For more details see the <a href="https://nixos.org/manual/nixos/stable/index.html#module-services-flatpak">NixOS documentation</a>.</p>
       </li>
       <li>
         <h2>Add the Flathub repository</h2>
         <p>Flathub is the best place to get Flatpak apps. To enable it, run:</p>
-        <pre><code>
-          <span class="unselectable">$</span> flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
-        </code></pre>
+        <terminal-command>
+          flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+        </terminal-command>
       </li>
       <li>
         <h2>Ready to go!</h2>
@@ -571,29 +549,29 @@
       <li>
         <h2>Install Flatpak</h2>
         <p>To install Flatpak on Turkman Linux, run the following in a terminal:</p>
-        <pre><code>
+        <terminal-command>
           <span class="unselectable">Emerge way</span>
-          <span class="unselectable">#</span> ymp install build-base --no-emerge
-          <span class="unselectable">#</span> ymp install flatpak
+          ymp install build-base --no-emerge
+          ymp install flatpak
           <span class="unselectable">No emerge way</span>
-          <span class="unselectable">#</span> ymp install flatpak --no-emerge
-        </code></pre>
+          ymp install flatpak --no-emerge
+        </terminal-command>
       </li>
       <li>
         <h2>Enable services</h2>
         <p>To enable services on Turkman Linux, run the following in a terminal:</p>
-        <pre><code>
-          <span class="unselectable">#</span> rc-service add devfs
-          <span class="unselectable">#</span> rc-service add fuse
-          <span class="unselectable">#</span> rc-service add hostname
-        </code></pre>
+        <terminal-command>
+          rc-service add devfs
+          rc-service add fuse
+          rc-service add hostname
+        </terminal-command>
       </li>
       <li>
         <h2>Add the Flathub repository</h2>
         <p>Flathub is the best place to get Flatpak apps. To enable it, run:</p>
-        <pre><code>
-           <span class="unselectable">$</span> flatpak --user remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
-        </code></pre>
+        <terminal-command>
+           flatpak --user remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+        </terminal-command>
       </li>
       <li>
         <h2>Restart</h2>
@@ -610,16 +588,16 @@
       <li>
         <h2>Install Flatpak</h2>
         <p>To install Flatpak, run the following:</p>
-        <pre><code>
-          <span class="unselectable">$</span> sudo neko em flatpak
-        </code></pre>
+        <terminal-command>
+          sudo neko em flatpak
+        </terminal-command>
       </li>
       <li>
         <h2>Add the Flathub repository</h2>
         <p>Flathub is the best place to get Flatpak apps. To enable it, run:</p>
-        <pre><code>
-          <span class="unselectable">$</span> flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
-        </code></pre>
+        <terminal-command>
+          flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+        </terminal-command>
       </li>
       <li>
         <h2>Restart</h2>
@@ -641,24 +619,24 @@
       <li>
         <h2>Install Flatpak</h2>
         <p>To install Flatpak, run the following:</p>
-        <pre><code>
-          <span class="unselectable">$</span> sudo apt install flatpak
-        </code></pre>
+        <terminal-command>
+          sudo apt install flatpak
+        </terminal-command>
       </li>
       <li>
         <h2>Add the Flathub repository</h2>
         <p>Flathub is the best place to get Flatpak apps. To enable it, run:</p>
-        <pre><code>
-          <span class="unselectable">$</span> flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
-        </code></pre>
+        <terminal-command>
+          flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+        </terminal-command>
       </li>
       <li>
         <h2>Install the Deepin themes</h2>
         <p>To install light and dark themes, run:</p>
-        <pre><code>
-          <span class="unselectable">$</span> flatpak install flathub org.gtk.Gtk3theme.deepin
-          <span class="unselectable">$</span> flatpak install flathub org.gtk.Gtk3theme.deepin-dark
-        </code></pre>
+        <terminal-command>
+          flatpak install flathub org.gtk.Gtk3theme.deepin
+          flatpak install flathub org.gtk.Gtk3theme.deepin-dark
+        </terminal-command>
       </li>
       <li>
         <h2>Restart</h2>
@@ -673,24 +651,24 @@
       <li>
         <h2>Install Flatpak</h2>
         <p>A flatpak package is available in Pardus 2019 and newer. To install it, run the following as root:</p>
-        <pre><code>
-          <span class="unselectable">#</span> apt install flatpak
-        </code></pre>
+        <terminal-command>
+          apt install flatpak
+        </terminal-command>
         <p>For Pardus 2017 and older versions, a flatpak package is available in the <a href="https://backports.debian.org/Instructions/">official backports repository</a>. </p>
       </li>
       <li>
         <h2>Install the Software Flatpak plugin</h2>
         <p>If you are running GNOME, it is also a good idea to install the Flatpak plugin for GNOME Software. To do this, run:</p>
-        <pre><code>
-          <span class="unselectable">#</span> apt install gnome-software-plugin-flatpak
-        </code></pre>
+        <terminal-command>
+          apt install gnome-software-plugin-flatpak
+        </terminal-command>
       </li>
       <li>
         <h2>Add the Flathub repository</h2>
         <p>Flathub is the best place to get Flatpak apps. To enable it, run:</p>
-        <pre><code>
-          <span class="unselectable">#</span> flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
-        </code></pre>
+        <terminal-command>
+          flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+        </terminal-command>
       </li>
       <li>
         <h2>Restart</h2>
@@ -722,16 +700,16 @@
       <li>
         <h2>Install Flatpak</h2>
         <p>A flatpak package is available in Pisi 2.1 and newer. To install it, run the following as root:</p>
-        <pre><code>
-          <span class="unselectable">$</span> sudo pisi it flatpak
-        </code></pre>
+        <terminal-command>
+          sudo pisi it flatpak
+        </terminal-command>
       </li>
       <li>
         <h2>Add the Flathub repository</h2>
         <p>Flathub is the best place to get Flatpak apps. To enable it, run:</p>
-        <pre><code>
-          <span class="unselectable">$</span> flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
-        </code></pre>
+        <terminal-command>
+          flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+        </terminal-command>
       </li>
       <li>
         <h2>Restart</h2>
@@ -748,20 +726,20 @@
       <li>
         <h2>Install Flatpak</h2>
         <p>To install Flatpak on EndeavorOS, you must first make sure your installation is up to date, run the following in a terminal:</p>
-        <pre><code>
-          <span class="unselectable">$</span> sudo pacman -Syu
-        </code></pre>
+        <terminal-command>
+          sudo pacman -Syu
+        </terminal-command>
         <p>Then install Flatpak:</p>
-          <pre><code>
-          <span class="unselectable">$</span> sudo pacman -S flatpak
-        </code></pre>
+          <terminal-command>
+          sudo pacman -S flatpak
+        </terminal-command>
       </li>
       <li>
         <h2>Add the Flathub repository</h2>
         <p>Flathub is the best place to get Flatpak apps. To enable it, run:</p>
-        <pre><code>
-          <span class="unselectable">$</span> flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
-        </code></pre>
+        <terminal-command>
+          flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+        </terminal-command>
       </li>
       <li>
         <h2>Restart</h2>
@@ -789,16 +767,16 @@
       <li>
         <h2>Install Flatpak</h2>
         <p>Flatpak can be installed from GNU Guix's default repositories. Run the following in a terminal:</p>
-        <pre><code>
-          <span class="unselectable">$</span> guix install flatpak
-        </code></pre>
+        <terminal-command>
+          guix install flatpak
+        </terminal-command>
       </li>
       <li>
         <h2>Add the Flathub repository</h2>
         <p>Flathub is the best place to get Flatpak apps. To enable it, run:</p>
-        <pre><code>
-          <span class="unselectable">$</span> flatpak --user remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
-        </code></pre>
+        <terminal-command>
+          flatpak --user remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+        </terminal-command>
       </li>
       <li>
         <h2>Restart</h2>

--- a/source/javascripts/command.js
+++ b/source/javascripts/command.js
@@ -1,0 +1,39 @@
+// A web component to display a terminal command with a copy button.
+
+// Icons are from https://github.com/lucide-icons/lucide
+const copyIcon = `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg>`;
+const checkIcon = `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg>`;
+
+// Define custom element, so we can do <terminal-command>apt install flatpak</terminal-command>
+class TerminalCommand extends HTMLElement {
+  constructor() {
+    super();
+  }
+  connectedCallback() {
+    const commands = this.textContent
+      .trim()
+      .split("\n")
+      .map((command) => command.trim())
+      .filter(Boolean);
+
+    this.innerHTML = "";
+
+    const code = document.createElement("code");
+    code.innerHTML = commands
+      .map((command) => `<span class="unselectable">$</span> ${command}`)
+      .join("\n");
+    this.appendChild(code);
+
+    const button = document.createElement("button");
+    button.title = "Copy the command to clipboard";
+    button.innerHTML = copyIcon;
+    button.addEventListener("click", () => {
+      navigator.clipboard.writeText(commands.join("\n"));
+      button.innerHTML = checkIcon;
+      setTimeout(() => (button.innerHTML = copyIcon), 1000);
+    });
+    this.appendChild(button);
+  }
+}
+
+customElements.define("terminal-command", TerminalCommand);

--- a/source/layouts/layout.haml
+++ b/source/layouts/layout.haml
@@ -21,6 +21,7 @@
   = javascript_include_tag "jquery.toc.min"
   = javascript_include_tag :bootstrap
   = javascript_include_tag :all
+  = javascript_include_tag :command, defer: true
   = matomo
 
   %body#page-top

--- a/source/stylesheets/site.css.scss
+++ b/source/stylesheets/site.css.scss
@@ -944,3 +944,25 @@ ol.distrotut {
   font-variation-settings: 'wght' 600;
   font-size: 90%;
 }
+
+terminal-command {
+  @extend pre;
+  display: flex;
+  align-items: center;
+  gap: 1em;
+  code {
+    flex: 1;
+    padding: 1em;
+  }
+  button {
+    padding: 0.5em;
+    border: none;
+    background: transparent;
+    display: flex;
+    align-items: center;
+    svg {
+      width: 1.5em;
+      height: 1.5em;
+    }
+  }
+}


### PR DESCRIPTION
This PR adds a copy button to all terminal commands.
![image](https://github.com/flatpak/flatpak.github.io/assets/35634442/360a3ac8-18f5-4f6c-8e8c-124767346137)


`distro.yml` file already had a lot of repeating html so instead of adding a button to each command there I added a custom component `<terminal-command>` that adds a button and a dollar sign before every line on page load.