### PR TITLE
Transform distro data into introductions and steps

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -17,7 +17,7 @@ page '/*.txt', layout: false
 #  which_fake_page: "Rendering a fake page with a local variable" }
 
 data.distro.each do |i|
-  proxy "/setup/#{i.slug ? i.slug : i.name}.html", "/distro-template.html", :locals => { :name => i.name, :logo => i.logo, :info => i.info, :slug => i.slug }, :ignore => true
+  proxy "/setup/#{i.slug ? i.slug : i.name}.html", "/distro-template.html", :locals => { :name => i.name, :logo => i.logo, :introduction => i.introduction, :steps => i.steps, :slug => i.slug }, :ignore => true
 end
 
 # General configuration

--- a/data/distro.yml
+++ b/data/distro.yml
@@ -1,4 +1,4 @@
-- name: "Ubuntu"
+- name: Ubuntu
   logo: "ubuntu.svg"
   steps:
     - name: Install Flatpak
@@ -11,12 +11,12 @@
         sudo apt update\n
         sudo apt install flatpak\n
       </terminal-command>"
-    - name: "Install the Software Flatpak plugin"
+    - name: Install the Software Flatpak plugin
       text: "
       <p>The Flatpak plugin for the Software app makes it possible to install apps without needing the command line. To install, run:</p>
       <terminal-command>sudo apt install gnome-software-plugin-flatpak</terminal-command>
       <p>Note: the Software app is distributed as a Snap since Ubuntu 20.04 and does not support graphical installation of Flatpak apps. Installing the Flatpak plugin will also install a deb version of Software and result in two Software apps being installed at the same time.</p>"
-    - name: "Add the Flathub repository"
+    - name: Add the Flathub repository
       text: "
       <p>Flathub is the best place to get Flatpak apps. To enable it, run:</p>
       <terminal-command>
@@ -26,7 +26,7 @@
       text: '
       <p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>'
 
-- name: "Fedora"
+- name: Fedora
   logo: "fedora.svg"
   introduction: >
     <!-- Flatpak has been installed by default on Fedora Workstation since F25. Previous versions are past end of life, so don’t need to be mentioned. -->
@@ -37,7 +37,7 @@
       flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
     </terminal-command>
 
-- name: "Manjaro"
+- name: Manjaro
   logo: "manjaro.svg"
   steps:
     - name: Enable Flatpak through the Software Manager
@@ -50,18 +50,18 @@
       text: '
       <p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>'
 
-- name: "Endless OS"
+- name: Endless OS
   logo: "endless.svg"
   introduction: >
     <h2>Flatpak support is built into Endless OS 3.0.0 and newer—no setup required!</h2>
     <p>If you are using an older version, <a href="https://community.endlessos.com/t/upgrade-from-endless-os-2-x-to-endless-os-3/967">upgrade to Endless OS 3</a>.</p>
 
-- name: "Chrome OS"
+- name: Chrome OS
   logo: "chrome-os.svg"
   introduction: >
     <p>Flatpak applications can be installed on ChromeOS with the Crostini Linux compatibility layer. This is not available for all ChromeOS devices, so you should ensure your device is compatible before proceeding. A list of compatible devices is maintained <a href="https://www.reddit.com/r/Crostini/wiki/getstarted/crostini-enabled-devices">here</a>.</p>
   steps:
-    - name: "Enable Linux support"
+    - name: Enable Linux support
       text: '
       <p>Navigate to <a href="chrome://os-settings">chrome://os-settings</a>, and scroll down to <strong>Developers</strong> and turn on <i>Linux development environment</i>. ChromeOS will take some time downloading and installing Linux.</p>'
     - name: Start a Linux terminal
@@ -84,7 +84,7 @@
       text: '
       <p>To complete setup, restart Linux. You can do this by right-clicking terminal, and then clicking "Shut down Linux". Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>'
 
-- name: "Red Hat Enterprise Linux"
+- name: Red Hat Enterprise Linux
   logo: "redhat.svg"
   introduction: <h2>Install Flatpak</h2>
     <p>Flatpak is installed by default on Red Hat Enterprise Linux Workstation 9 and newer. To get started, all you need to do is enable Flathub, which is the best way to get Flatpak apps. Just download and install the <a class="btn btn-default" href="https://dl.flathub.org/repo/flathub.flatpakrepo">Flathub repository file</a>.</p>
@@ -97,13 +97,13 @@
       flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
     </terminal-command>
 
-- name: "Linux Mint"
+- name: Linux Mint
   logo: "mint.svg"
   introduction:
     <h2>Flatpak support is built into Linux Mint 18.3 and newer—no setup required!</h2>
     <p>If you are using an older version, <a href="https://blog.linuxmint.com/?p=3462">upgrade to Linux Mint 18.3</a>.</p>
 
-- name: "openSUSE"
+- name: openSUSE
   logo: "opensuse.svg"
   steps:
     - name: Install Flatpak
@@ -122,7 +122,7 @@
       text: '
       <p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>'
 
-- name: "Arch"
+- name: Arch
   logo: "arch.svg"
   steps:
     - name: Install Flatpak
@@ -133,20 +133,20 @@
       text: '
         <p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>'
 
-- name: "Debian"
+- name: Debian
   logo: "debian.svg"
   steps:
     - name: Install Flatpak
       text: "
         <p>A flatpak package is available in Debian 10 (Buster) and newer. To install it, run the following as root:</p>
         <terminal-command>apt install flatpak</terminal-command>"
-    - name: "Install the Software Flatpak plugin"
+    - name: Install the Software Flatpak plugin
       text: "
         <p>If you are running GNOME, it is also a good idea to install the Flatpak plugin for GNOME Software. To do this, run:</p>
         <terminal-command>apt install gnome-software-plugin-flatpak</terminal-command>
         <p>If you are running KDE, you should instead install the Plasma Discover Flatpak backend:</p>
         <terminal-command>apt install plasma-discover-backend-flatpak</terminal-command>"
-    - name: "Add the Flathub repository"
+    - name: Add the Flathub repository
       text: '
         <p>Flathub is the best place to get Flatpak apps. To enable it, download and install the <a class="btn btn-default" href="https://dl.flathub.org/repo/flathub.flatpakrepo">Flathub repository file</a> or run the following in a terminal:</p>
         <terminal-command>
@@ -156,10 +156,10 @@
       text: '
         <p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>'
 
-- name: "Rocky Linux"
+- name: Rocky Linux
   logo: "rockylinux.svg"
   steps:
-    - name: "Install Flatpak"
+    - name: Install Flatpak
       text: "
         <p>Flatpak is installed by default on Rocky Linux 8 and newer, when installed with a software selection that includes GNOME (Server with GUI, Workstation). If you are using such a system, you may skip this step. To install Flatpak on Rocky Linux, run the following in a terminal:</p>
         <terminal-command>sudo dnf install flatpak</terminal-command>"
@@ -173,28 +173,28 @@
       text: '
         <p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>'
 
-- name: "CentOS"
+- name: CentOS
   logo: "cent-os.svg"
   introduction: >
     <p>Flatpak is installed by default on CentOS 7 and newer, when using GNOME. To get started, all you need to do is enable Flathub, which is the best way to get Flatpak apps. Just download and install the <a class="btn btn-default" href="https://dl.flathub.org/repo/flathub.flatpakrepo">Flathub repository file</a>.</p>
     <p>Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>
 
-- name: "EuroLinux"
+- name: EuroLinux
   logo: "eurolinux.svg"
   introduction: >
     <p>Flatpak is installed by default on EuroLinux 8 and newer, when using GNOME. To get started, all you need to do is enable Flathub, which is the best way to get Flatpak apps. Just download and install the <a class="btn btn-default" href="https://dl.flathub.org/repo/flathub.flatpakrepo">Flathub repository file</a>.</p>
     <p>Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>
 
-- name: "AlmaLinux"
+- name: AlmaLinux
   logo: "almalinux.svg"
   introduction: >
     <p>Flatpak is installed by default on AlmaLinux 8 and newer, when using GNOME. To get started, all you need to do is enable Flathub, which is the best way to get Flatpak apps. Just download and install the <a class="btn btn-default" href="https://dl.flathub.org/repo/flathub.flatpakrepo">Flathub repository file</a>.</p>
     <p>Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>
 
-- name: "Gentoo"
+- name: Gentoo
   logo: "gentoo.svg"
   steps:
-    - name: "Install Flatpak"
+    - name: Install Flatpak
       text: "
         <p>To install Flatpak, enable the ~amd64 keyword for sys-apps/flatpak, acct-user/flatpak and acct-group/flatpak:</p>
         <terminal-command>echo -e 'sys-apps/flatpak ~amd64\\nacct-user/flatpak ~amd64\\nacct-group/flatpak ~amd64\\ndev-util/ostree ~amd64' >> /etc/portage/package.accept_keywords/flatpak</terminal-command>
@@ -211,7 +211,7 @@
         <p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>
         <p>Note: graphical installation of Flatpak apps may not be possible with Gentoo.</p>'
 
-- name: "Kubuntu"
+- name: Kubuntu
   logo: "kubuntu.svg"
   steps:
     - name: Install Flatpak
@@ -224,7 +224,7 @@
         sudo apt update\n
         sudo apt install flatpak\n
       </terminal-command>"
-    - name: "Install the Discover Flatpak backend"
+    - name: Install the Discover Flatpak backend
       text: "
       <p>The Flatpak plugin for the Software app makes it possible to install apps without needing the command line (available on Kubuntu 18.04 and newer). To install on 20.04 or later, run:</p>
       <terminal-command>
@@ -234,7 +234,7 @@
       <terminal-command>
         sudo apt install plasma-discover-flatpak-backend
       </terminal-command>"
-    - name: "Add the Flathub repository"
+    - name: Add the Flathub repository
       text: '
       <p>Flathub is the best place to get Flatpak apps. To enable it, download and install the <a class="btn btn-default" href="https://dl.flathub.org/repo/flathub.flatpakrepo">Flathub repository file</a> or run the following in a terminal:</p>
       <terminal-command>
@@ -244,10 +244,10 @@
       text: '
       <p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>'
 
-- name: "Solus"
+- name: Solus
   logo: "solus.svg"
   steps:
-    - name: "Install Flatpak"
+    - name: Install Flatpak
       text: "
       <p>To install Flatpak on Solus, simply run:</p>
       <terminal-command>sudo eopkg install flatpak</terminal-command>"
@@ -262,20 +262,20 @@
       <p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>
       <p>Note: graphical installation of Flatpak apps is not yet possible with Solus, but will be available in the near future.</p>'
 
-- name: "Alpine"
+- name: Alpine
   logo: "alpine.svg"
   steps:
     - name: Install Flatpak
       text: "
       <p>Flatpak can be installed from the community repository. Run the following in a terminal:</p>
       <terminal-command>doas apk add flatpak</terminal-command>"
-    - name: "Install the Software Flatpak plugin"
+    - name: Install the Software Flatpak plugin
       text: "
       <p>You can install the Flatpak plugin for either the GNOME Software (since v3.13) or KDE Discover (since v3.11), making it possible to install apps without needing the command line. To install, for GNOME Software run:</p>
       <terminal-command>doas apk add gnome-software-plugin-flatpak</terminal-command>
       <p>For KDE Discover run:</p>
       <terminal-command>doas apk add discover-backend-flatpak</terminal-command>"
-    - name: "Add the Flathub repository"
+    - name: Add the Flathub repository
       text: "
       <p>Flathub is the best place to get Flatpak apps. To enable it, download and install the <a class='btn btn-default' href='https://dl.flathub.org/repo/flathub.flatpakrepo'>Flathub repository file</a> or run the following in a terminal:</p>
       <terminal-command>
@@ -285,16 +285,16 @@
       text: '
       <p>To complete the setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>'
 
-- name: "Mageia"
+- name: Mageia
   logo: "mageia.svg"
   steps:
-    - name: "Install Flatpak"
+    - name: Install Flatpak
       text: "
         <p>A flatpak package is available for Mageia 6 and newer. To install with DNF, run the following as root:</p>
         <terminal-command>dnf install flatpak</terminal-command>
         <p>Or, to install with <code>urpmi</code>, run:</p>
         <terminal-command>urpmi flatpak</terminal-command>"
-    - name: "Add the Flathub repository"
+    - name: Add the Flathub repository
       text: "
         <p>Flathub is the best place to get Flatpak apps. To enable it, download and install the <a class='btn btn-default' href='https://dl.flathub.org/repo/flathub.flatpakrepo'>Flathub repository file</a> or run the following in a terminal:</p>
         <terminal-command>
@@ -311,11 +311,11 @@
     <h2>Flatpak support is built into Pop!_OS 20.04 and newer—no setup required!</h2>
     <p>If you are using an older version, you can refer to the instructions below.</p>
   steps:
-    - name: "Install Flatpak"
+    - name: Install Flatpak
       text: "
         <p>To install Flatpak on Pop!_OS 19.10 and earlier, simply run:</p>
         <terminal-command>sudo apt install flatpak</terminal-command>"
-    - name: "Add the Flathub repository"
+    - name: Add the Flathub repository
       text: "<p>Flathub is the best place to get Flatpak apps. To enable it, download and install the <a class='btn btn-default' href='https://dl.flathub.org/repo/flathub.flatpakrepo'>Flathub repository file</a> or run the following in a terminal:</p>
       <terminal-command>
         flatpak remote-add --user --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
@@ -325,24 +325,24 @@
             <p>Note: graphical installation of Flatpak apps may not be possible with Pop!_OS 19.10 and earlier.</p>'
 
 
-- name: "elementary OS"
+- name: elementary OS
   logo: "elementary-os.svg"
   logo_dark: "elementary-os-dark.svg"
   steps:
-    - name: "Install Some Apps"
+    - name: Install Some Apps
       text: '<p>elementary OS 5.1 and newer comes with Flatpak support out of the box. For non-curated apps, head to <a href="https://flathub.org/">Flathub</a> to install any app using the big "Install" button, and open the downloaded `.flatpakref` file with Sideload.</p>
       <p>Note: After installing one app from a remote like Flathub, all other apps from that remote will also automatically show up in AppCenter.</p>'
 
-- name: "Raspberry Pi OS"
+- name: Raspberry Pi OS
   logo: "raspberry-pi-os.svg"
   steps:
-    - name: "Install Flatpak"
+    - name: Install Flatpak
       text: '
         <p>A flatpak package is available in Raspberry Pi OS (previously called Raspbian) Stretch and newer. To install it, run the following as root:</p>
         <terminal-command>
           apt install flatpak
         </terminal-command>'
-    - name: "Add the Flathub repository"
+    - name: Add the Flathub repository
       text: "
         <p>Flathub is the best place to get Flatpak apps. To enable it, run:</p>
         <terminal-command>
@@ -353,7 +353,7 @@
       text: '<p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>
       <p>Note: graphical installation of Flatpak apps may not be possible with Raspberry Pi OS.</p>'
 
-- name: "Clear Linux"
+- name: Clear Linux
   logo: "clearlinux.svg"
   introduction: >
     <p>Flatpak is installed and Flathub repository is pre-configured by default on Clear Linux when installing the desktop bundle.</p>
@@ -362,28 +362,28 @@
     </terminal-command>
     <p>Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>
 
-- name: "Void Linux"
+- name: Void Linux
   logo: "void.svg"
   logo_dark: "void-dark.svg"
   steps:
-    - name: "Install Flatpak"
+    - name: Install Flatpak
       text: '
         <p>To install Flatpak on Void Linux, run the following in a terminal:</p>
         <terminal-command>sudo xbps-install -S flatpak</terminal-command>'
-    - name: "Add the Flathub repository"
+    - name: Add the Flathub repository
       text: '
         <p>Flathub is the best place to get Flatpak apps. To enable it, run:</p>
         <terminal-command>
           flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
         </terminal-command>'
-    - name: "Restart"
+    - name: Restart
       text: '
         <p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>'
 
-- name: "NixOS"
+- name: NixOS
   logo: "nixos.svg"
   steps:
-    - name: "Install Flatpak"
+    - name: Install Flatpak
       text: "
         <p>To install Flatpak, set NixOS option <code>services.flatpak.enable</code> to <code>true</code> by putting the following into your <code>/etc/nixos/configuration.nix</code>:</p>
         <terminal-command>
@@ -394,27 +394,27 @@
           sudo nixos-rebuild switch
         </terminal-command>
         <p>For more details see the <a href='https://nixos.org/manual/nixos/stable/index.html#module-services-flatpak'>NixOS documentation</a>.</p>"
-    - name: "Add the Flathub repository"
+    - name: Add the Flathub repository
       text: '
         <p>Flathub is the best place to get Flatpak apps. To enable it, run:</p>
         <terminal-command>
           flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
         </terminal-command>'
-    - name: "Restart"
+    - name: Restart
       text: '
         <p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>'
 
-- name: "PureOS"
+- name: PureOS
   logo: "pureos.svg"
   logo_dark: "pureos-dark.svg"
   introduction: >
     <p>Flatpak is installed by default on PureOS. To get started, all you need to do is enable Flathub, which is the best way to get Flatpak apps. Just download and install the <a class="btn btn-default" href="https://dl.flathub.org/repo/flathub.flatpakrepo">Flathub repository file</a>.</p>
     <p>Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>
 
-- name: "Turkman Linux"
+- name: Turkman Linux
   logo: "turkman.svg"
   steps:
-    - name: "Install Flatpak"
+    - name: Install Flatpak
       text: '
         <p>To install Flatpak on Turkman Linux, run the following in a terminal:</p>
         <p>Emerge way</p>
@@ -426,7 +426,7 @@
         <terminal-command>
           ymp install flatpak --no-emerge
         </terminal-command>'
-    - name: "Enable services"
+    - name: Enable services
       text: '
         <p>To enable services on Turkman Linux, run the following in a terminal:</p>
         <terminal-command>
@@ -434,103 +434,103 @@
           rc-service add fuse\n
           rc-service add hostname\n
         </terminal-command>'
-    - name: "Add the Flathub repository"
+    - name: Add the Flathub repository
       text: '
         <p>Flathub is the best place to get Flatpak apps. To enable it, run:</p>
         <terminal-command>
           flatpak --user remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
         </terminal-command>'
-    - name: "Restart"
+    - name: Restart
       text: '
         <p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>
         <p>Note: graphical installation of Flatpak apps may not be possible with Turkman Linux.</p>'
 
-- name: "Ataraxia Linux"
+- name: Ataraxia Linux
   logo: "ataraxia.svg"
   logo_dark: "ataraxia-dark.svg"
   steps:
-    - name: "Install Flatpak"
+    - name: Install Flatpak
       text: '
         <p>To install Flatpak on Ataraxia Linux, run the following in a terminal:</p>
         <terminal-command>
           sudo neko em flatpak
         </terminal-command>'
-    - name: "Add the Flathub repository"
+    - name: Add the Flathub repository
       text: '
         <p>Flathub is the best place to get Flatpak apps. To enable it, run:</p>
         <terminal-command>
           flatpak --user remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
         </terminal-command>'
-    - name: "Restart"
+    - name: Restart
       text: '
         <p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>'
 
-- name: "Zorin OS"
+- name: Zorin OS
   logo: "zorin-os.svg"
   introduction: >
     <h2>Flatpak support is built into Zorin OS</h2>
     <p>You can use the Software Store app to download flatpak apps.</p>
 
-- name: "Deepin"
+- name: Deepin
   logo: "deepin.svg"
   steps:
-    - name: "Install Flatpak"
+    - name: Install Flatpak
       text: '
         <p>To install Flatpak on Deepin, run the following in a terminal:</p>
         <terminal-command>
           sudo apt install flatpak
         </terminal-command>'
-    - name: "Add the Flathub repository"
+    - name: Add the Flathub repository
       text: '
         <p>Flathub is the best place to get Flatpak apps. To enable it, run:</p>
         <terminal-command>
           flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
         </terminal-command>'
-    - name: "Install the Deepin themes"
+    - name: Install the Deepin themes
       text: '
         <p>To install light and dark themes, run:</p>
         <terminal-command>
           flatpak install flathub org.gtk.Gtk3theme.deepin\n
           flatpak install flathub org.gtk.Gtk3theme.deepin-dark\n
         </terminal-command>'
-    - name: "Restart"
+    - name: Restart
       text: '
         <p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>'
 
-- name: "Pardus"
+- name: Pardus
   logo: "pardus.svg"
   steps:
-    - name: "Install Flatpak"
+    - name: Install Flatpak
       text: '
         <p>A flatpak package is available in Pardus 2019 and newer. To install it, run the following as root:</p>
         <terminal-command>
           apt install flatpak
         </terminal-command>
         <p>For Pardus 2017 and older versions, a flatpak package is available in the <a href="https://backports.debian.org/Instructions/">official backports repository</a>. </p>'
-    - name: "Install the Software Flatpak plugin"
+    - name: Install the Software Flatpak plugin
       text: '
         <p>If you are running GNOME, it is also a good idea to install the Flatpak plugin for GNOME Software. To do this, run:</p>
         <terminal-command>
           apt install gnome-software-plugin-flatpak
         </terminal-command>'
-    - name: "Add the Flathub repository"
+    - name: Add the Flathub repository
       text: '
         <p>Flathub is the best place to get Flatpak apps. To enable it, run:</p>
         <terminal-command>
           flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
         </terminal-command>'
-    - name: "Restart"
+    - name: Restart
       text: '
         <p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>'
 
-- name: "MX Linux"
+- name: MX Linux
   logo: "mxlinux.svg"
   steps:
-    - name: "Enable Flatpak through the Software Manager"
+    - name: Enable Flatpak through the Software Manager
       text: '
         <p>Flatpak support is built in from MX 18 and later. It is only required to activate the Flathub repository following these instructions:</p>
         <p>Open <strong>MX Package Installer</strong> (open the menu and look in MX Tools), select the "Flatpaks" tab, to activate the repository you will need to enter the root password.</p>'
-    - name: "Restart"
+    - name: Restart
       text: '
         <p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>'
 
@@ -539,24 +539,24 @@
   logo: "pisi.svg"
   logo_dark: "pisi-dark.svg"
   steps:
-    - name: "Install Flatpak"
+    - name: Install Flatpak
       text: '
         <p>A flatpak package is available in Pisi 2.1 and newer. To install it, run the following as root:</p>
         <terminal-command>
           sudo pisi it flatpak
         </terminal-command>'
-    - name: "Add the Flathub repository"
+    - name: Add the Flathub repository
       text: '
         <p>Flathub is the best place to get Flatpak apps. To enable it, run:</p>
         <terminal-command>
           flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
         </terminal-command>'
-    - name: "Restart"
+    - name: Restart
       text: '
         <p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>
         <p>Note: graphical installation of Flatpak apps may not be possible with Pisi GNU/Linux.</p>'
 
-- name: "EndeavourOS"
+- name: EndeavourOS
   logo: "endeavouros.svg"
   logo_dark: "endeavouros-dark.svg"
   steps:
@@ -570,7 +570,7 @@
       <terminal-command>
         sudo pacman -S flatpak
       </terminal-command>'
-    - name: "Add the Flathub repository"
+    - name: Add the Flathub repository
       text: "<p>Flathub is the best place to get Flatpak apps. To enable it, run:</p>
       <terminal-command>
         flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
@@ -579,34 +579,34 @@
       text: '<p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>
       <p>Note: graphical installation of Flatpak apps may not be possible with EndeavourOS.</p>'
 
-- name: "KDE neon"
+- name: KDE neon
   logo: "kdeneon.svg"
   introduction:
     <h2>Flatpak support is built into KDE neon 19 and newer—no setup required!</h2>
     <p>If you are using an older version, you can refer to the instructions below.</p>
   steps:
-    - name: "Enable Flatpak"
+    - name: Enable Flatpak
       text: "Open Discover and click on Settings (lower left corner)."
-    - name: "Check Flatpak settings"
+    - name: Check Flatpak settings
       text: "<p>Check that in the Flatpak section the box is checked.</p><p>Note: with this Flathub app search will be integrated in Discover, if you want to limit the app search to Flathub you can mark Flatpak as default by clicking on the star.</p>"
 
-- name: "GNU Guix"
+- name: GNU Guix
   logo: "guix.svg"
   logo_dark: "guix-dark.svg"
   steps:
-    - name: "Install Flatpak"
+    - name: Install Flatpak
       text: '
         <p>To install Flatpak on GNU Guix, run the following in a terminal:</p>
         <terminal-command>
           guix install flatpak
         </terminal-command>'
-    - name: "Add the Flathub repository"
+    - name: Add the Flathub repository
       text: "
         <p>Flathub is the best place to get Flatpak apps. To enable it, run:</p>
         <terminal-command>
           flatpak --user remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
         </terminal-command>"
-    - name: "Restart"
+    - name: Restart
       text: '
         <p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>
         <p>Note: graphical installation of Flatpak apps may not be possible with GNU Guix.</p>'

--- a/data/distro.yml
+++ b/data/distro.yml
@@ -1,790 +1,612 @@
 - name: "Ubuntu"
   logo: "ubuntu.svg"
-  info: >
-    <ol class="distrotut">
-      <li>
-        <h2>Install Flatpak</h2>
-        <p>To install Flatpak on Ubuntu 18.10 (Cosmic Cuttlefish) or later, simply run:</p>
-        <terminal-command>sudo apt install flatpak</terminal-command>
-        <p>With older Ubuntu versions, the official Flatpak PPA is the recommended way to install Flatpak. To install it, run the following in a terminal:</p>
-        <terminal-command>
-          sudo add-apt-repository ppa:flatpak/stable
-          sudo apt update
-          sudo apt install flatpak
-        </terminal-command>
-      </li>
-      <li>
-        <h2>Install the Software Flatpak plugin</h2>
-        <p>The Flatpak plugin for the Software app makes it possible to install apps without needing the command line. To install, run:</p>
-        <terminal-command>sudo apt install gnome-software-plugin-flatpak</terminal-command>
-        <p>Note: the Software app is distributed as a Snap since Ubuntu 20.04 and does not support graphical installation of Flatpak apps. Installing the Flatpak plugin will also install a deb version of Software and result in two Software apps being installed at the same time.</p>
-      </li>
-      <li>
-        <h2>Add the Flathub repository</h2>
-        <p>Flathub is the best place to get Flatpak apps. To enable it, run:</p>
-        <terminal-command>
-          flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
-        </terminal-command>
-      </li>
-      <li>
-        <h2>Restart</h2>
-        <p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>
-      </li>
-    </ol>
+  steps:
+    - name: Install Flatpak
+      text: "
+      <p>To install Flatpak on Ubuntu 18.10 (Cosmic Cuttlefish) or later, simply run:</p>
+      <terminal-command>sudo apt install flatpak</terminal-command>
+      <p>With older Ubuntu versions, the official Flatpak PPA is the recommended way to install Flatpak. To install it, run the following in a terminal:</p>
+      <terminal-command>
+        sudo add-apt-repository ppa:flatpak/stable\n
+        sudo apt update\n
+        sudo apt install flatpak\n
+      </terminal-command>"
+    - name: "Install the Software Flatpak plugin"
+      text: "
+      <p>The Flatpak plugin for the Software app makes it possible to install apps without needing the command line. To install, run:</p>
+      <terminal-command>sudo apt install gnome-software-plugin-flatpak</terminal-command>
+      <p>Note: the Software app is distributed as a Snap since Ubuntu 20.04 and does not support graphical installation of Flatpak apps. Installing the Flatpak plugin will also install a deb version of Software and result in two Software apps being installed at the same time.</p>"
+    - name: "Add the Flathub repository"
+      text: "
+      <p>Flathub is the best place to get Flatpak apps. To enable it, run:</p>
+      <terminal-command>
+      flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+      </terminal-command>"
+    - name: 'Restart'
+      text: '
+      <p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>'
 
 - name: "Fedora"
   logo: "fedora.svg"
-  info: >
-    <ol class="distrotut">
-      <!-- Flatpak has been installed by default on Fedora Workstation since F25. Previous versions are past end of life, so don’t need to be mentioned. -->
-      <p>Flatpak is installed by default on Fedora Workstation, Fedora Silverblue, and Fedora Kinoite. To get started, all you need to do is enable Flathub, which is the best way to get Flatpak apps. Just download and install the <a class="btn btn-default" href="https://dl.flathub.org/repo/flathub.flatpakrepo">Flathub repository file</a>.</p>
-      <p>Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>
-      <p>The above links should work on the default GNOME and KDE Fedora installations, but if they fail for some reason you can manually add the Flathub remote by running:</p>
-      <terminal-command>
-        flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
-      </terminal-command>
-    </ol>
+  introduction: >
+    <!-- Flatpak has been installed by default on Fedora Workstation since F25. Previous versions are past end of life, so don’t need to be mentioned. -->
+    <p>Flatpak is installed by default on Fedora Workstation, Fedora Silverblue, and Fedora Kinoite. To get started, all you need to do is enable Flathub, which is the best way to get Flatpak apps. Just download and install the <a class="btn btn-default" href="https://dl.flathub.org/repo/flathub.flatpakrepo">Flathub repository file</a>.</p>
+    <p>Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>
+    <p>The above links should work on the default GNOME and KDE Fedora installations, but if they fail for some reason you can manually add the Flathub remote by running:</p>
+    <terminal-command>
+      flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+    </terminal-command>
 
 - name: "Manjaro"
   logo: "manjaro.svg"
-  info: >
-    <ol class="distrotut">
-      <li>
-        <h2>Enable Flatpak through the Software Manager</h2>
-        <p>Flatpak is installed by default on Manjaro 20 or higher.</p>
-        <p>To enable its support, navigate to the <strong>Software Manager</strong> (Add/Remove Programs)</p>
-        <p>Click on the triple line menu [or dots depending on the Desktop Environment] on the right, in the drop down menu select "Preferences"</p>
-        <p>Navigate to the "Flatpak" tab and slide the toggle to Enable Flatpak support (it is also possible to enable checking for updates, which is recommended).</p>
-      </li>
-      <li>
-        <h2>Restart</h2>
-        <p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>
-      </li>
-    </ol>
+  steps:
+    - name: Enable Flatpak through the Software Manager
+      text: '
+      <p>Flatpak is installed by default on Manjaro 20 or higher.</p>
+      <p>To enable its support, navigate to the <strong>Software Manager</strong> (Add/Remove Programs)</p>
+      <p>Click on the triple line menu [or dots depending on the Desktop Environment] on the right, in the drop down menu select "Preferences"</p>
+      <p>Navigate to the "Flatpak" tab and slide the toggle to Enable Flatpak support (it is also possible to enable checking for updates, which is recommended).</p>'
+    - name: Restart
+      text: '
+      <p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>'
 
 - name: "Endless OS"
   logo: "endless.svg"
-  info: >
-    <ol class="distrotut">
-      <h2>Flatpak support is built into Endless OS 3.0.0 and newer—no setup required!</h2>
-      <p>If you are using an older version, <a href="https://community.endlessos.com/t/upgrade-from-endless-os-2-x-to-endless-os-3/967">upgrade to Endless OS 3</a>.</p>
-    </ol>
+  introduction: >
+    <h2>Flatpak support is built into Endless OS 3.0.0 and newer—no setup required!</h2>
+    <p>If you are using an older version, <a href="https://community.endlessos.com/t/upgrade-from-endless-os-2-x-to-endless-os-3/967">upgrade to Endless OS 3</a>.</p>
 
 - name: "Chrome OS"
   logo: "chrome-os.svg"
-  info: >    
-    <ol class="distrotut">
-      <p>Flatpak applications can be installed on ChromeOS with the Crostini Linux compatibility layer. This is not available for all ChromeOS devices, so you should ensure your device is compatible before proceeding. A list of compatible devices is maintained <a href="https://www.reddit.com/r/Crostini/wiki/getstarted/crostini-enabled-devices">here</a>.</p>
-      <li>
-        <h2>Enable Linux support</h2>
-        <p>Navigate to <a href="chrome://os-settings">chrome://os-settings</a>, and scroll down to <strong>Developers</strong> and turn on <i>Linux development environment</i>. ChromeOS will take some time downloading and installing Linux.</p>
-      </li>
-      <li>
-        <h2>Start a Linux terminal</h2>
-        <p>Press the Search/Launcher key, type "Terminal", and launch the Terminal app.</p>
-      </li>
-      <li>
-        <h2>Install Flatpak</h2>
-        <p>To install Flatpak, run the following in the terminal:</p>
-        <terminal-command>
-          sudo apt install flatpak
-        </terminal-command>
-        <p>A more up to date flatpak package is available in the <a href="https://backports.debian.org/Instructions/">Debian backports repository</a>. </p>
-      </li>
-      <li>
-        <h2>Add the Flathub repository</h2>
-        <p>Flathub is the best place to get Flatpak apps. To enable it, run:</p>
-        <terminal-command>
-          flatpak --user remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
-        </terminal-command>
-      </li>
-      <li>
-        <h2>Restart</h2>
-        <p>To complete setup, restart Linux. You can do this by right-clicking terminal, and then clicking "Shut down Linux". Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>
-      </li>
-    </ol>
+  introduction: >
+    <p>Flatpak applications can be installed on ChromeOS with the Crostini Linux compatibility layer. This is not available for all ChromeOS devices, so you should ensure your device is compatible before proceeding. A list of compatible devices is maintained <a href="https://www.reddit.com/r/Crostini/wiki/getstarted/crostini-enabled-devices">here</a>.</p>
+  steps:
+    - name: "Enable Linux support"
+      text: '
+      <p>Navigate to <a href="chrome://os-settings">chrome://os-settings</a>, and scroll down to <strong>Developers</strong> and turn on <i>Linux development environment</i>. ChromeOS will take some time downloading and installing Linux.</p>'
+    - name: Start a Linux terminal
+      text: '
+      <p>Press the Search/Launcher key, type "Terminal", and launch the Terminal app.</p>'
+    - name: Install Flatpak
+      text: '
+      <p>To install Flatpak, run the following in the terminal:</p>
+      <terminal-command>
+      sudo apt install flatpak
+      </terminal-command>
+      <p>A more up to date flatpak package is available in the <a href="https://backports.debian.org/Instructions/">Debian backports repository</a>. </p>'
+    - name: Add the Flathub repository
+      text: "
+      <p>Flathub is the best place to get Flatpak apps. To enable it, run:</p>
+      <terminal-command>
+      flatpak --user remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+      </terminal-command>"
+    - name: Restart
+      text: '
+      <p>To complete setup, restart Linux. You can do this by right-clicking terminal, and then clicking "Shut down Linux". Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>'
 
 - name: "Red Hat Enterprise Linux"
   logo: "redhat.svg"
-  info: >
-    <ol class="distrotut">
-      <h2>Install Flatpak</h2>
-      <p>Flatpak is installed by default on Red Hat Enterprise Linux Workstation 9 and newer. To get started, all you need to do is enable Flathub, which is the best way to get Flatpak apps. Just download and install the <a class="btn btn-default" href="https://dl.flathub.org/repo/flathub.flatpakrepo">Flathub repository file</a>.</p>
-      <p>To install Flatpak on Red Hat Enterprise Linux Workstation 8 or older, run the following in a terminal:</p>
-      <!-- Apparently the GNOME Software Flatpak plugin is shipped as part of the GNOME Software package, so there’s no need to separately install it -->
-      <terminal-command>sudo yum install flatpak</terminal-command>
-      <p>Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>
-      <p>The above links should work on the default Red Hat Enterprise Linux Workstation 9 installation, but if they fail for some reason you can manually add the Flathub remote by running:</p>
-      <terminal-command>
-        flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
-      </terminal-command>
-    </ol>
+  introduction: <h2>Install Flatpak</h2>
+    <p>Flatpak is installed by default on Red Hat Enterprise Linux Workstation 9 and newer. To get started, all you need to do is enable Flathub, which is the best way to get Flatpak apps. Just download and install the <a class="btn btn-default" href="https://dl.flathub.org/repo/flathub.flatpakrepo">Flathub repository file</a>.</p>
+    <p>To install Flatpak on Red Hat Enterprise Linux Workstation 8 or older, run the following in a terminal:</p>
+    <!-- Apparently the GNOME Software Flatpak plugin is shipped as part of the GNOME Software package, so there’s no need to separately install it -->
+    <terminal-command>sudo yum install flatpak</terminal-command>
+    <p>Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>
+    <p>The above links should work on the default Red Hat Enterprise Linux Workstation 9 installation, but if they fail for some reason you can manually add the Flathub remote by running:</p>
+    <terminal-command>
+    flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+    </terminal-command>
 
 - name: "Linux Mint"
   logo: "mint.svg"
-  info: >
-    <ol class="distrotut">
-      <h2>Flatpak support is built into Linux Mint 18.3 and newer—no setup required!</h2>
-      <p>If you are using an older version, <a href="https://blog.linuxmint.com/?p=3462">upgrade to Linux Mint 18.3</a>.</p>
-    </ol>
+  introduction:
+    <h2>Flatpak support is built into Linux Mint 18.3 and newer—no setup required!</h2>
+    <p>If you are using an older version, <a href="https://blog.linuxmint.com/?p=3462">upgrade to Linux Mint 18.3</a>.</p>
 
 - name: "openSUSE"
   logo: "opensuse.svg"
-  info: >
-    <ol class="distrotut">
-      <li>
-        <h2>Install Flatpak</h2>
-        <p>Flatpak is available in the default repositories of all currently maintained openSUSE Leap and openSUSE Tumbleweed versions.</p>
-        <p>If you prefer a graphical installation, you can install Flatpak using a "1-click installer" from <a href="https://software.opensuse.org/package/flatpak">software.opensuse.org</a>. If your distribution version is not shown by default, click <em>Show flatpak for other distributions</em> first and then select from the list.</p>
-        <p>Alternatively, install Flatpak from the command line using Zypper:</p>
-        <terminal-command>sudo zypper install flatpak</terminal-command>
-      </li>
-      <li>
-        <h2>Add the Flathub repository</h2>
-        <p>Flathub is the best place to get Flatpak apps. To enable it, run:</p>
-        <terminal-command>
-          flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
-        </terminal-command>
-      </li>
-      <li>
-        <h2>Restart</h2>
-        <p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>
-      </li>
-    </ol>
+  steps:
+    - name: Install Flatpak
+      text: '
+      <p>Flatpak is available in the default repositories of all currently maintained openSUSE Leap and openSUSE Tumbleweed versions.</p>
+      <p>If you prefer a graphical installation, you can install Flatpak using a "1-click installer" from <a href="https://software.opensuse.org/package/flatpak">software.opensuse.org</a>. If your distribution version is not shown by default, click <em>Show flatpak for other distributions</em> first and then select from the list.</p>
+      <p>Alternatively, install Flatpak from the command line using Zypper:</p>
+      <terminal-command>sudo zypper install flatpak</terminal-command>'
+    - name: Add the Flathub repository
+      text: "
+      <p>Flathub is the best place to get Flatpak apps. To enable it, run:</p>
+      <terminal-command>
+      flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+      </terminal-command>"
+    - name: 'Restart'
+      text: '
+      <p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>'
 
 - name: "Arch"
   logo: "arch.svg"
-  info: >
-    <ol class="distrotut">
-      <li>
-        <h2>Install Flatpak</h2>
-        <p>To install Flatpak, run the following in a terminal:</p>
-        <terminal-command>sudo pacman -S flatpak</terminal-command>
-      </li>
-      <!-- On arch, Flathub is added when the Flatpak package is installed. -->
-      <!-- Apparently the GNOME Software Flatpak plugin is shipped as part of the GNOME Software package, so there's no need to separately install it -->
-      <li>
-        <h2>Restart</h2>
-        <p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>
-      </li>
-    </ol>
+  steps:
+    - name: Install Flatpak
+      text: "
+        <p>To install Flatpak on Arch, simply run:</p>
+        <terminal-command>sudo pacman -S flatpak</terminal-command>"
+    - name: Restart
+      text: '
+        <p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>'
 
 - name: "Debian"
   logo: "debian.svg"
-  info: >
-    <ol class="distrotut">
-      <li>
-        <h2>Install Flatpak</h2>
-        <p>A flatpak package is available in Debian Buster and newer. To install it, run the following as root:</p>
-        <terminal-command>apt install flatpak</terminal-command>
-      </li>
-      <li>
-        <h2>Install the Software Flatpak plugin</h2>
+  steps:
+    - name: Install Flatpak
+      text: "
+        <p>A flatpak package is available in Debian 10 (Buster) and newer. To install it, run the following as root:</p>
+        <terminal-command>apt install flatpak</terminal-command>"
+    - name: "Install the Software Flatpak plugin"
+      text: "
         <p>If you are running GNOME, it is also a good idea to install the Flatpak plugin for GNOME Software. To do this, run:</p>
         <terminal-command>apt install gnome-software-plugin-flatpak</terminal-command>
-        <p>If you are running KDE Plasma, you can install the Flatpak plugin for KDE Discover instead:</p>
-        <terminal-command>apt install plasma-discover-backend-flatpak</terminal-command>
-      </li>
-      <li>
-        <h2>Add the Flathub repository</h2>
-        <p>Flathub is the best place to get Flatpak apps. To enable it, run:</p>
+        <p>If you are running KDE, you should instead install the Plasma Discover Flatpak backend:</p>
+        <terminal-command>apt install plasma-discover-backend-flatpak</terminal-command>"
+    - name: "Add the Flathub repository"
+      text: '
+        <p>Flathub is the best place to get Flatpak apps. To enable it, download and install the <a class="btn btn-default" href="https://dl.flathub.org/repo/flathub.flatpakrepo">Flathub repository file</a> or run the following in a terminal:</p>
         <terminal-command>
-          flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
-        </terminal-command>
-      </li>
-      <li>
-        <h2>Restart</h2>
-        <p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>
-      </li>
-    </ol>
+        flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+        </terminal-command>'
+    - name: 'Restart'
+      text: '
+        <p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>'
 
 - name: "Rocky Linux"
   logo: "rockylinux.svg"
-  info: >
-    <ol class="distrotut">
-      <li>
-        <h2>Install Flatpak</h2>
+  steps:
+    - name: "Install Flatpak"
+      text: "
         <p>Flatpak is installed by default on Rocky Linux 8 and newer, when installed with a software selection that includes GNOME (Server with GUI, Workstation). If you are using such a system, you may skip this step. To install Flatpak on Rocky Linux, run the following in a terminal:</p>
-        <terminal-command>sudo dnf install flatpak</terminal-command>
-      </li>
-      <li>
-        <h2>Add the Flathub repository</h2>
-        <p>Flathub is the best way to get Flatpak apps. To enable it, download and install the <a class="btn btn-default" href="https://dl.flathub.org/repo/flathub.flatpakrepo">Flathub repository file</a>, or run the following in a terminal:</p>
+        <terminal-command>sudo dnf install flatpak</terminal-command>"
+    - name: Add the Flathub repository
+      text: '
+        <p>Flathub is the best place to get Flatpak apps. To enable it, download and install the <a class="btn btn-default" href="https://dl.flathub.org/repo/flathub.flatpakrepo">Flathub repository file</a> or run the following in a terminal:</p>
         <terminal-command>
-          flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
-        </terminal-command>
-      </li>
-      <li>
-        <h2>Restart</h2>
-        <p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>
-      </li>
-    </ol>
+        flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+        </terminal-command>'
+    - name: 'Restart'
+      text: '
+        <p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>'
 
 - name: "CentOS"
   logo: "cent-os.svg"
-  info: >
-    <ol class="distrotut">
-      <p>Flatpak is installed by default on CentOS 7 and newer, when using GNOME. To get started, all you need to do is enable Flathub, which is the best way to get Flatpak apps. Just download and install the <a class="btn btn-default" href="https://dl.flathub.org/repo/flathub.flatpakrepo">Flathub repository file</a>.</p>
-      <p>Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>
-    </ol>
+  introduction: >
+    <p>Flatpak is installed by default on CentOS 7 and newer, when using GNOME. To get started, all you need to do is enable Flathub, which is the best way to get Flatpak apps. Just download and install the <a class="btn btn-default" href="https://dl.flathub.org/repo/flathub.flatpakrepo">Flathub repository file</a>.</p>
+    <p>Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>
 
 - name: "EuroLinux"
   logo: "eurolinux.svg"
-  info: >
-    <ol class="distrotut">
-      <p>Flatpak is installed by default on EuroLinux 8 and newer, when using GNOME. To get started, all you need to do is enable Flathub, which is the best way to get Flatpak apps. Just download and install the <a class="btn btn-default" href="https://dl.flathub.org/repo/flathub.flatpakrepo">Flathub repository file</a>.</p>
-      <p>Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>
-    </ol>
+  introduction: >
+    <p>Flatpak is installed by default on EuroLinux 8 and newer, when using GNOME. To get started, all you need to do is enable Flathub, which is the best way to get Flatpak apps. Just download and install the <a class="btn btn-default" href="https://dl.flathub.org/repo/flathub.flatpakrepo">Flathub repository file</a>.</p>
+    <p>Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>
 
 - name: "AlmaLinux"
   logo: "almalinux.svg"
-  info: >
-    <ol class="distrotut">
-      <p>Flatpak is installed by default on AlmaLinux 8 and newer, when using GNOME. To get started, all you need to do is enable Flathub, which is the best way to get Flatpak apps. Just download and install the <a class="btn btn-default" href="https://dl.flathub.org/repo/flathub.flatpakrepo">Flathub repository file</a>.</p>
-      <p>Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>
-    </ol>
+  introduction: >
+    <p>Flatpak is installed by default on AlmaLinux 8 and newer, when using GNOME. To get started, all you need to do is enable Flathub, which is the best way to get Flatpak apps. Just download and install the <a class="btn btn-default" href="https://dl.flathub.org/repo/flathub.flatpakrepo">Flathub repository file</a>.</p>
+    <p>Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>
 
 - name: "Gentoo"
   logo: "gentoo.svg"
-  info: >
-    <ol class="distrotut">
-      <li>
-        <h2>Install Flatpak</h2>
+  steps:
+    - name: "Install Flatpak"
+      text: "
         <p>To install Flatpak, enable the ~amd64 keyword for sys-apps/flatpak, acct-user/flatpak and acct-group/flatpak:</p>
-        <terminal-command>
-          echo -e 'sys-apps/flatpak ~amd64\nacct-user/flatpak ~amd64\nacct-group/flatpak ~amd64\ndev-util/ostree ~amd64' >> /etc/portage/package.accept_keywords/flatpak
-        </terminal-command>
+        <terminal-command>echo -e 'sys-apps/flatpak ~amd64\\nacct-user/flatpak ~amd64\\nacct-group/flatpak ~amd64\\ndev-util/ostree ~amd64' >> /etc/portage/package.accept_keywords/flatpak</terminal-command>
         <p>Then, install Flatpak:</p>
-        <terminal-command>emerge sys-apps/flatpak</terminal-command>
-      </li>
-      <li>
-        <h2>Add the Flathub repository</h2>
+        <terminal-command>emerge sys-apps/flatpak</terminal-command>"
+    - name: Add the Flathub repository
+      text: "
         <p>Flathub is the best place to get Flatpak apps. To enable it, run:</p>
         <terminal-command>
-          flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
-        </terminal-command>
-      </li>
-      <li>
-        <h2>Restart</h2>
+        flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+        </terminal-command>"
+    - name: 'Restart'
+      text: '
         <p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>
-        <p>Note: graphical installation of Flatpak apps may not be possible with Gentoo.</p>
-      </li>
-    </ol>
+        <p>Note: graphical installation of Flatpak apps may not be possible with Gentoo.</p>'
 
 - name: "Kubuntu"
   logo: "kubuntu.svg"
-  info: >
-    <ol class="distrotut">
-      <li>
-        <h2>Install Flatpak</h2>
-        <p>To install Flatpak on Kubuntu 18.10 (Cosmic Cuttlefish) or later, simply run:</p>
-        <terminal-command>sudo apt install flatpak</terminal-command>
-        <p>With older Kubuntu versions, the official Flatpak PPA is the recommended way to install Flatpak. To install it, run the following in a terminal:</p>
-        <terminal-command>
-          sudo add-apt-repository ppa:alexlarsson/flatpak
-          sudo apt update
-          sudo apt install flatpak
-        </terminal-command>
-      </li>
-      <li>
-        <h2>Install the Discover Flatpak backend</h2>
-        <p>The Flatpak plugin for the Software app makes it possible to install apps without needing the command line (available on Kubuntu 18.04 and newer). To install on 20.04 or later, run:</p>
-        <terminal-command>
-          sudo apt install plasma-discover-backend-flatpak
-        </terminal-command>
-        <p>On Kubuntu 18.04, you should run this instead:</p>
-        <terminal-command>
-          sudo apt install plasma-discover-flatpak-backend
-        </terminal-command>
-      </li>
-      <li>
-        <h2>Add the Flathub repository</h2>
-        <p>Flathub is the best place to get Flatpak apps. To enable it, run:</p>
-        <terminal-command>
-          flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
-        </terminal-command>
-      </li>
-      <li>
-        <h2>Restart</h2>
-        <p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>
-      </li>
-    </ol>
+  steps:
+    - name: Install Flatpak
+      text: "
+      <p>To install Flatpak on Kubuntu 18.10 (Cosmic Cuttlefish) or later, simply run:</p>
+      <terminal-command>sudo apt install flatpak</terminal-command>
+      <p>With older Kubuntu versions, the official Flatpak PPA is the recommended way to install Flatpak. To install it, run the following in a terminal:</p>
+      <terminal-command>
+      sudo add-apt-repository ppa:alexlarsson/flatpak\n
+      sudo apt update\n
+      sudo apt install flatpak\n
+      </terminal-command>"
+    - name: "Install the Discover Flatpak backend"
+      text: "
+      <p>The Flatpak plugin for the Software app makes it possible to install apps without needing the command line (available on Kubuntu 18.04 and newer). To install on 20.04 or later, run:</p>
+      <terminal-command>
+      sudo apt install plasma-discover-backend-flatpak
+      </terminal-command>
+      <p>On Kubuntu 18.04, you should run this instead:</p>
+      <terminal-command>
+      sudo apt install plasma-discover-flatpak-backend
+      </terminal-command>"
+    - name: "Add the Flathub repository"
+      text: '
+      <p>Flathub is the best place to get Flatpak apps. To enable it, download and install the <a class="btn btn-default" href="https://dl.flathub.org/repo/flathub.flatpakrepo">Flathub repository file</a> or run the following in a terminal:</p>
+      <terminal-command>
+      flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+      </terminal-command>'
+    - name: 'Restart'
+      text: '
+      <p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>'
 
 - name: "Solus"
   logo: "solus.svg"
-  info: >
-    <ol class="distrotut">
-      <li>
-        <h2>Install Flatpak</h2>
-        <p>To install Flatpak, run the following in a terminal:</p>
-        <terminal-command>
-          sudo eopkg install flatpak
-        </terminal-command>
-      </li>
-      <li>
-        <h2>Add the Flathub repository</h2>
-        <p>Flathub is the best place to get Flatpak apps. To enable it, run:</p>
-        <terminal-command>
-          flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
-        </terminal-command>
-      </li>
-      <li>
-        <h2>Restart</h2>
-        <p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>
-        <p>Note: graphical installation of Flatpak apps is not yet possible with Solus, but will be available in the near future.</p>
-      </li>
-    </ol>
+  steps:
+    - name: "Install Flatpak"
+      text: "
+      <p>To install Flatpak on Solus, simply run:</p>
+      <terminal-command>sudo eopkg install flatpak</terminal-command>"
+    - name: Add the Flathub repository
+      text: '
+      <p>Flathub is the best place to get Flatpak apps. To enable it, download and install the <a class="btn btn-default" href="https://dl.flathub.org/repo/flathub.flatpakrepo">Flathub repository file</a> or run the following in a terminal:</p>
+      <terminal-command>
+      flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+      </terminal-command>'
+    - name: 'Restart'
+      text: '
+      <p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>
+      <p>Note: graphical installation of Flatpak apps is not yet possible with Solus, but will be available in the near future.</p>'
 
 - name: "Alpine"
   logo: "alpine.svg"
-  info: >
-    <ol class="distrotut">
-      <li>
-        <h2>Install Flatpak</h2>
-        <p>Flatpak can be installed from the community repository. Run the following in a terminal:</p>
-        <terminal-command>
-          doas apk add flatpak
-        </terminal-command>
-      </li>
-      <li>
-        <h2>Install the Software Flatpak plugin</h2>
-        <p>You can install the Flatpak plugin for either the GNOME Software (since v3.13) or KDE Discover (since v3.11), making it possible to install apps without needing the command line. To install, for GNOME Software run:</p>
-        <terminal-command>
-          doas apk add gnome-software-plugin-flatpak
-        </terminal-command>
-        <p>And for KDE Discover, run this instead:</p>
-        <terminal-command>
-          doas apk add discover-backend-flatpak
-        </terminal-command>
-      </li>
-      <li>
-        <h2>Add the Flathub repository</h2>
-        <p>Flathub is the best place to get Flatpak apps. To enable it, run:</p>
-        <terminal-command>
-          flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
-        </terminal-command>
-      </li>
-      <li>
-        <h2>Restart</h2>
-        <p>To complete the setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>
-      </li>
-    </ol>
+  steps:
+    - name: Install Flatpak
+      text: "
+      <p>Flatpak can be installed from the community repository. Run the following in a terminal:</p>
+      <terminal-command>doas apk add flatpak</terminal-command>"
+    - name: "Install the Software Flatpak plugin"
+      text: "
+      <p>You can install the Flatpak plugin for either the GNOME Software (since v3.13) or KDE Discover (since v3.11), making it possible to install apps without needing the command line. To install, for GNOME Software run:</p>
+      <terminal-command>doas apk add gnome-software-plugin-flatpak</terminal-command>
+      <p>For KDE Discover run:</p>
+      <terminal-command>doas apk add discover-backend-flatpak</terminal-command>"
+    - name: "Add the Flathub repository"
+      text: "
+      <p>Flathub is the best place to get Flatpak apps. To enable it, download and install the <a class='btn btn-default' href='https://dl.flathub.org/repo/flathub.flatpakrepo'>Flathub repository file</a> or run the following in a terminal:</p>
+      <terminal-command>
+      flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+      </terminal-command>"
+    - name: 'Restart'
+      text: '
+      <p>To complete the setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>'
 
 - name: "Mageia"
   logo: "mageia.svg"
-  info: >
-    <ol class="distrotut">
-      <li>
-        <h2>Install Flatpak</h2>
+  steps:
+    - name: "Install Flatpak"
+      text: "
         <p>A flatpak package is available for Mageia 6 and newer. To install with DNF, run the following as root:</p>
-        <terminal-command>
-          dnf install flatpak
-        </terminal-command>
+        <terminal-command>dnf install flatpak</terminal-command>
         <p>Or, to install with <code>urpmi</code>, run:</p>
+        <terminal-command>urpmi flatpak</terminal-command>"
+    - name: "Add the Flathub repository"
+      text: "
+        <p>Flathub is the best place to get Flatpak apps. To enable it, download and install the <a class='btn btn-default' href='https://dl.flathub.org/repo/flathub.flatpakrepo'>Flathub repository file</a> or run the following in a terminal:</p>
         <terminal-command>
-          urpmi flatpak
-        </terminal-command>
-      </li>
-      <li>
-        <h2>Add the Flathub repository</h2>
-        <p>Flathub is the best place to get Flatpak apps. To enable it, run:</p>
-        <terminal-command>
-          flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
-        </terminal-command>
-      </li>
-      <li>
-        <h2>Restart</h2>
+        flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+        </terminal-command>"
+    - name: 'Restart'
+      text: '
         <p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>
-        <p>Note: graphical installation of Flatpak apps may not be possible with Mageia.</p>
-      </li>
-    </ol>
+        <p>Note: graphical installation of Flatpak apps may not be possible with Mageia.</p>'
 
 - name: "Pop!_OS"
   logo: "pop-os.svg"
-  info: >
-    <ol class="distrotut">
-      <h2>Pop!_OS 20.04 has Flatpak installed and Flathub configured by default. The Pop!_Shop can be used to install flatpaks.</h2>
-      <p>For older versions of Pop!_OS, see the instructions below.</p>
-      <li>
-        <h2>Install Flatpak</h2>
+  introduction: >
+    <h2>Flatpak support is built into Pop!_OS 20.04 and newer—no setup required!</h2>
+    <p>If you are using an older version, you can refer to the instructions below.</p>
+  steps:
+    - name: "Install Flatpak"
+      text: "
         <p>To install Flatpak on Pop!_OS 19.10 and earlier, simply run:</p>
-        <terminal-command>
-          sudo apt install flatpak
-        </terminal-command>
-      </li>
-      <li>
-        <h2>Add the Flathub repository</h2>
-        <p>Flathub is the best place to get Flatpak apps. To enable it, run:</p>
-        <terminal-command>
-          flatpak remote-add --user --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
-        </terminal-command>
-      </li>
-      <li>
-        <h2>Restart</h2>
-        <p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>
-        <p>Note: graphical installation of Flatpak apps may not be possible with Pop!_OS 19.10 and earlier.</p>
-      </li>
-    </ol>
+        <terminal-command>sudo apt install flatpak</terminal-command>"
+    - name: "Add the Flathub repository"
+      text: "<p>Flathub is the best place to get Flatpak apps. To enable it, download and install the <a class='btn btn-default' href='https://dl.flathub.org/repo/flathub.flatpakrepo'>Flathub repository file</a> or run the following in a terminal:</p>
+      <terminal-command>
+      flatpak remote-add --user --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+      </terminal-command>"
+    - name: 'Restart'
+      text: '<p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>
+            <p>Note: graphical installation of Flatpak apps may not be possible with Pop!_OS 19.10 and earlier.</p>'
+
 
 - name: "elementary OS"
   logo: "elementary-os.svg"
   logo_dark: "elementary-os-dark.svg"
-  info: >
-    <ol class="distrotut">
-      <!-- As of elementary OS 5.1 up-to-date Flatpak is installed, AppCenter supports it ootb, and Sideload handles .flatpakref files -->
-      <li>
-        <h2>Install Some Apps</h2>
-        <!-- Curated apps in elementary OS will move to Flatpak by default, but Flathub is not included -->
-        <!-- However, the Flathub remote will be added automatically when installing a Flathub app for the first time with Sideload -->
-        <p>elementary OS 5.1 and newer comes with Flatpak support out of the box. For non-curated apps, head to <a href="https://flathub.org/">Flathub</a> to install any app using the big "Install" button, and open the downloaded `.flatpakref` file with Sideload.</p>
-        <p>Note: After installing one app from a remote like Flathub, all other apps from that remote will also automatically show up in AppCenter.</p>
-      </li>
-    </ol>
+  steps:
+    - name: "Install Some Apps"
+      text: '<p>elementary OS 5.1 and newer comes with Flatpak support out of the box. For non-curated apps, head to <a href="https://flathub.org/">Flathub</a> to install any app using the big "Install" button, and open the downloaded `.flatpakref` file with Sideload.</p>
+      <p>Note: After installing one app from a remote like Flathub, all other apps from that remote will also automatically show up in AppCenter.</p>'
 
 - name: "Raspberry Pi OS"
   logo: "raspberry-pi-os.svg"
-  info: >
-    <ol class="distrotut">
-      <li>
-        <h2>Install Flatpak</h2>
+  steps:
+    - name: "Install Flatpak"
+      text: '
         <p>A flatpak package is available in Raspberry Pi OS (previously called Raspbian) Stretch and newer. To install it, run the following as root:</p>
         <terminal-command>
-          apt install flatpak
-        </terminal-command>
-      </li>
-      <li>
-        <h2>Add the Flathub repository</h2>
+        apt install flatpak
+        </terminal-command>'
+    - name: "Add the Flathub repository"
+      text: "
         <p>Flathub is the best place to get Flatpak apps. To enable it, run:</p>
         <terminal-command>
-          flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+        flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
         </terminal-command>
-        <p><b>Important note:</b> As of March 2021, Raspberry Pi computers still ship with the 32-bit version of Raspberry Pi OS. However Flathub started phasing out support for that architecture. If you consider Flathub as an important source of applications, it is recommended to use Raspberry Pi OS 64-bit as newer applications are more likely to be available for that platform.</p>
-      </li>
-      <li>
-        <h2>Restart</h2>
-        <p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>
-        <p>Note: graphical installation of Flatpak apps may not be possible with Raspberry Pi OS.</p>
-      </li>
-    </ol>
+        <p><b>Important note:</b> As of March 2021, Raspberry Pi computers still ship with the 32-bit version of Raspberry Pi OS. However Flathub started phasing out support for that architecture. If you consider Flathub as an important source of applications, it is recommended to use Raspberry Pi OS 64-bit as newer applications are more likely to be available for that platform.</p>"
+    - name: 'Restart'
+      text: '<p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>
+      <p>Note: graphical installation of Flatpak apps may not be possible with Raspberry Pi OS.</p>'
 
 - name: "Clear Linux"
   logo: "clearlinux.svg"
-  info: >
-    <ol class="distrotut">
-      <p>Flatpak is installed and Flathub repository is pre-configured by default on Clear Linux when installing the desktop bundle.</p>
-      <terminal-command>
-        sudo swupd bundle-add desktop
-      </terminal-command>
-      <p>Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>
-    </ol>
+  introduction: >
+    <p>Flatpak is installed and Flathub repository is pre-configured by default on Clear Linux when installing the desktop bundle.</p>
+    <terminal-command>
+      sudo swupd bundle-add desktop
+    </terminal-command>
+    <p>Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>
 
 - name: "Void Linux"
   logo: "void.svg"
   logo_dark: "void-dark.svg"
-  info: >
-    <ol class="distrotut">
-      <li>
-        <h2>Install Flatpak</h2>
-        <p>To install Flatpak, run the following:</p>
-        <terminal-command>
-          sudo xbps-install -S flatpak
-        </terminal-command>
-      </li>
-      <li>
-        <h2>Add the Flathub repository</h2>
+  steps:
+    - name: "Install Flatpak"
+      text: '
+        <p>To install Flatpak on Void Linux, run the following in a terminal:</p>
+        <terminal-command>sudo xbps-install -S flatpak</terminal-command>'
+    - name: "Add the Flathub repository"
+      text: '
         <p>Flathub is the best place to get Flatpak apps. To enable it, run:</p>
         <terminal-command>
-          flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
-        </terminal-command>
-      </li>
-      <li>
-        <h2>Restart</h2>
-        <p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>
-      </li>
-    </ol>
+        flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+        </terminal-command>'
+    - name: "Restart"
+      text: '
+        <p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>'
 
 - name: "NixOS"
   logo: "nixos.svg"
-  info: >
-    <ol class="distrotut">
-      <li>
-        <h2>Install Flatpak</h2>
-        <p>
-          To install Flatpak, set NixOS option <code>services.flatpak.enable</code> to <code>true</code>
-          by putting the following into your <code>/etc/nixos/configuration.nix</code>:
-        </p>
+  steps:
+    - name: "Install Flatpak"
+      text: "
+        <p>To install Flatpak, set NixOS option <code>services.flatpak.enable</code> to <code>true</code> by putting the following into your <code>/etc/nixos/configuration.nix</code>:</p>
         <terminal-command>
-          services.flatpak.enable = true;
+        services.flatpak.enable = true;
         </terminal-command>
         <p>Then, rebuild and switch to the new configuration with:</p>
         <terminal-command>
-          sudo nixos-rebuild switch
+        sudo nixos-rebuild switch
         </terminal-command>
-        <p>For more details see the <a href="https://nixos.org/manual/nixos/stable/index.html#module-services-flatpak">NixOS documentation</a>.</p>
-      </li>
-      <li>
-        <h2>Add the Flathub repository</h2>
+        <p>For more details see the <a href='https://nixos.org/manual/nixos/stable/index.html#module-services-flatpak'>NixOS documentation</a>.</p>"
+    - name: "Add the Flathub repository"
+      text: '
         <p>Flathub is the best place to get Flatpak apps. To enable it, run:</p>
         <terminal-command>
-          flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
-        </terminal-command>
-      </li>
-      <li>
-        <h2>Ready to go!</h2>
-        <p>Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>
-      </li>
-    </ol>
+        flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+        </terminal-command>'
+    - name: "Restart"
+      text: '
+        <p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>'
 
 - name: "PureOS"
   logo: "pureos.svg"
   logo_dark: "pureos-dark.svg"
-  info: >
-    <ol class="distrotut">
-      <p>Flatpak is installed by default on PureOS. To get started, all you need to do is enable Flathub, which is the best way to get Flatpak apps. Just download and install the <a class="btn btn-default" href="https://dl.flathub.org/repo/flathub.flatpakrepo">Flathub repository file</a>.</p>
-      <p>Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>
-    </ol>
+  introduction: >
+    <p>Flatpak is installed by default on PureOS. To get started, all you need to do is enable Flathub, which is the best way to get Flatpak apps. Just download and install the <a class="btn btn-default" href="https://dl.flathub.org/repo/flathub.flatpakrepo">Flathub repository file</a>.</p>
+    <p>Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>
 
 - name: "Turkman Linux"
   logo: "turkman.svg"
-  info: >
-    <ol class="distrotut">
-      <li>
-        <h2>Install Flatpak</h2>
+  steps:
+    - name: "Install Flatpak"
+      text: '
         <p>To install Flatpak on Turkman Linux, run the following in a terminal:</p>
         <p>Emerge way</p>
         <terminal-command>
-          ymp install build-base --no-emerge
-          ymp install flatpak
+          ymp install build-base --no-emerge\n
+          ymp install flatpak\n
         </terminal-command>
         <p>No emerge way</p>
         <terminal-command>
           ymp install flatpak --no-emerge
-        </terminal-command>
-      </li>
-      <li>
-        <h2>Enable services</h2>
+        </terminal-command>'
+    - name: "Enable services"
+      text: '
         <p>To enable services on Turkman Linux, run the following in a terminal:</p>
         <terminal-command>
-          rc-service add devfs
-          rc-service add fuse
-          rc-service add hostname
-        </terminal-command>
-      </li>
-      <li>
-        <h2>Add the Flathub repository</h2>
+          rc-service add devfs\n
+          rc-service add fuse\n
+          rc-service add hostname\n
+        </terminal-command>'
+    - name: "Add the Flathub repository"
+      text: '
         <p>Flathub is the best place to get Flatpak apps. To enable it, run:</p>
         <terminal-command>
-           flatpak --user remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
-        </terminal-command>
-      </li>
-      <li>
-        <h2>Restart</h2>
+          flatpak --user remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+        </terminal-command>'
+    - name: "Restart"
+      text: '
         <p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>
-        <p>Note: graphical installation of Flatpak apps may not be possible with Turkman Linux.</p>
-      </li>
-    </ol>
+        <p>Note: graphical installation of Flatpak apps may not be possible with Turkman Linux.</p>'
 
 - name: "Ataraxia Linux"
   logo: "ataraxia.svg"
   logo_dark: "ataraxia-dark.svg"
-  info: >
-    <ol class="distrotut">
-      <li>
-        <h2>Install Flatpak</h2>
-        <p>To install Flatpak, run the following:</p>
+  steps:
+    - name: "Install Flatpak"
+      text: '
+        <p>To install Flatpak on Ataraxia Linux, run the following in a terminal:</p>
         <terminal-command>
           sudo neko em flatpak
-        </terminal-command>
-      </li>
-      <li>
-        <h2>Add the Flathub repository</h2>
+        </terminal-command>'
+    - name: "Add the Flathub repository"
+      text: '
         <p>Flathub is the best place to get Flatpak apps. To enable it, run:</p>
         <terminal-command>
-          flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
-        </terminal-command>
-      </li>
-      <li>
-        <h2>Restart</h2>
-        <p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>
-      </li>
-    </ol>
+          flatpak --user remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+        </terminal-command>'
+    - name: "Restart"
+      text: '
+        <p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>'
 
 - name: "Zorin OS"
   logo: "zorin-os.svg"
-  info: >
-    <ol class="distrotut">
-      <h2>Flatpak is installed by default on Zorin OS. You can use the Software Store app to download flatpak apps.</h2>
-    </ol>
+  introduction: >
+    <h2>Flatpak support is built into Zorin OS</h2>
+    <p>You can use the Software Store app to download flatpak apps.</p>
 
 - name: "Deepin"
   logo: "deepin.svg"
-  info: >
-    <ol class="distrotut">
-      <li>
-        <h2>Install Flatpak</h2>
-        <p>To install Flatpak, run the following:</p>
+  steps:
+    - name: "Install Flatpak"
+      text: '
+        <p>To install Flatpak on Deepin, run the following in a terminal:</p>
         <terminal-command>
           sudo apt install flatpak
-        </terminal-command>
-      </li>
-      <li>
-        <h2>Add the Flathub repository</h2>
+        </terminal-command>'
+    - name: "Add the Flathub repository"
+      text: '
         <p>Flathub is the best place to get Flatpak apps. To enable it, run:</p>
         <terminal-command>
           flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
-        </terminal-command>
-      </li>
-      <li>
-        <h2>Install the Deepin themes</h2>
+        </terminal-command>'
+    - name: "Install the Deepin themes"
+      text: '
         <p>To install light and dark themes, run:</p>
         <terminal-command>
-          flatpak install flathub org.gtk.Gtk3theme.deepin
-          flatpak install flathub org.gtk.Gtk3theme.deepin-dark
-        </terminal-command>
-      </li>
-      <li>
-        <h2>Restart</h2>
-        <p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>
-      </li>
-    </ol>
+          flatpak install flathub org.gtk.Gtk3theme.deepin\n
+          flatpak install flathub org.gtk.Gtk3theme.deepin-dark\n
+        </terminal-command>'
+    - name: "Restart"
+      text: '
+        <p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>'
 
 - name: "Pardus"
   logo: "pardus.svg"
-  info: >
-    <ol class="distrotut">
-      <li>
-        <h2>Install Flatpak</h2>
+  steps:
+    - name: "Install Flatpak"
+      text: '
         <p>A flatpak package is available in Pardus 2019 and newer. To install it, run the following as root:</p>
         <terminal-command>
           apt install flatpak
         </terminal-command>
-        <p>For Pardus 2017 and older versions, a flatpak package is available in the <a href="https://backports.debian.org/Instructions/">official backports repository</a>. </p>
-      </li>
-      <li>
-        <h2>Install the Software Flatpak plugin</h2>
+        <p>For Pardus 2017 and older versions, a flatpak package is available in the <a href="https://backports.debian.org/Instructions/">official backports repository</a>. </p>'
+    - name: "Install the Software Flatpak plugin"
+      text: '
         <p>If you are running GNOME, it is also a good idea to install the Flatpak plugin for GNOME Software. To do this, run:</p>
         <terminal-command>
           apt install gnome-software-plugin-flatpak
-        </terminal-command>
-      </li>
-      <li>
-        <h2>Add the Flathub repository</h2>
+        </terminal-command>'
+    - name: "Add the Flathub repository"
+      text: '
         <p>Flathub is the best place to get Flatpak apps. To enable it, run:</p>
         <terminal-command>
           flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
-        </terminal-command>
-      </li>
-      <li>
-        <h2>Restart</h2>
-        <p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>
-      </li>
-    </ol>
+        </terminal-command>'
+    - name: "Restart"
+      text: '
+        <p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>'
 
 - name: "MX Linux"
   logo: "mxlinux.svg"
-  info: >
-    <ol class="distrotut">
-      <li>
-        <h2>Enable Flatpak through the Software Manager</h2>
+  steps:
+    - name: "Enable Flatpak through the Software Manager"
+      text: '
         <p>Flatpak support is built in from MX 18 and later. It is only required to activate the Flathub repository following these instructions:</p>
-        <p>Open <strong>MX Package Installer</strong> (open the menu and look in MX Tools), select the "Flatpaks" tab, to activate the repository you will need to enter the root password.</p>
-      </li>
-      <li>
-        <h2>Restart</h2>
-        <p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>
-      </li>
-    </ol>
+        <p>Open <strong>MX Package Installer</strong> (open the menu and look in MX Tools), select the "Flatpaks" tab, to activate the repository you will need to enter the root password.</p>'
+    - name: "Restart"
+      text: '
+        <p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>'
 
 - name: "Pisi GNU/Linux"
   slug: "Pisi GNU Linux"
   logo: "pisi.svg"
   logo_dark: "pisi-dark.svg"
-  info: >
-    <ol class="distrotut">
-      <li>
-        <h2>Install Flatpak</h2>
+  steps:
+    - name: "Install Flatpak"
+      text: '
         <p>A flatpak package is available in Pisi 2.1 and newer. To install it, run the following as root:</p>
         <terminal-command>
           sudo pisi it flatpak
-        </terminal-command>
-      </li>
-      <li>
-        <h2>Add the Flathub repository</h2>
+        </terminal-command>'
+    - name: "Add the Flathub repository"
+      text: '
         <p>Flathub is the best place to get Flatpak apps. To enable it, run:</p>
         <terminal-command>
           flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
-        </terminal-command>
-      </li>
-      <li>
-        <h2>Restart</h2>
+        </terminal-command>'
+    - name: "Restart"
+      text: '
         <p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>
-        <p>Note: for now, graphical installation of Flatpak apps is not possible on Pisi GNU/Linux.</p>
-      </li>
-    </ol>
+        <p>Note: graphical installation of Flatpak apps may not be possible with Pisi GNU/Linux.</p>'
 
 - name: "EndeavourOS"
   logo: "endeavouros.svg"
   logo_dark: "endeavouros-dark.svg"
-  info: >
-    <ol class="distrotut">
-      <li>
-        <h2>Install Flatpak</h2>
-        <p>To install Flatpak on EndeavorOS, you must first make sure your installation is up to date, run the following in a terminal:</p>
-        <terminal-command>
-          sudo pacman -Syu
-        </terminal-command>
-        <p>Then install Flatpak:</p>
-          <terminal-command>
-          sudo pacman -S flatpak
-        </terminal-command>
-      </li>
-      <li>
-        <h2>Add the Flathub repository</h2>
-        <p>Flathub is the best place to get Flatpak apps. To enable it, run:</p>
-        <terminal-command>
-          flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
-        </terminal-command>
-      </li>
-      <li>
-        <h2>Restart</h2>
-        <p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>
-        <p>Note: graphical installation of Flatpak apps may not be possible with EndeavourOS.</p>
-      </li>
-    </ol>
+  steps:
+    - name:  'Install Flatpak'
+      text: '
+      <p>To install Flatpak on EndeavorOS, you must first make sure your installation is up to date, run the following in a terminal:</p>
+      <terminal-command>
+        sudo pacman -Syu
+      </terminal-command>
+      <p>Then install Flatpak:</p>
+      <terminal-command>
+        sudo pacman -S flatpak
+      </terminal-command>'
+    - name: "Add the Flathub repository"
+      text: "<p>Flathub is the best place to get Flatpak apps. To enable it, run:</p>
+      <terminal-command>
+        flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+      </terminal-command>"
+    - name: 'Restart'
+      text: '<p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>
+      <p>Note: graphical installation of Flatpak apps may not be possible with EndeavourOS.</p>'
 
 - name: "KDE neon"
   logo: "kdeneon.svg"
-  info: >
-    <ol class="distrotut">
-        <h2>Enable Flatpak through the Software Manager</h2>
-        <p>Flatpak support is built in by default from KDE neon 19 and later. To activate the <a href="https://flathub.org/">Flathub</a> repository in Discover, just follow the instructions below:</p>
-        <p>Open Discover and click on Settings (lower left corner).</p>
-        <p>Check that in the Flatpak section the box is checked.</p>
-        <p>Note: with this Flathub app search will be integrated in Discover, if you want to limit the app search to Flathub you can mark Flatpak as default by clicking on the star.</p>
-    </ol>
+  introduction:
+    <h2>Flatpak support is built into KDE neon 19 and newer—no setup required!</h2>
+    <p>If you are using an older version, you can refer to the instructions below.</p>
+  steps:
+    - name: "Enable Flatpak"
+      text: "Open Discover and click on Settings (lower left corner)."
+    - name: "Check Flatpak settings"
+      text: "<p>Check that in the Flatpak section the box is checked.</p><p>Note: with this Flathub app search will be integrated in Discover, if you want to limit the app search to Flathub you can mark Flatpak as default by clicking on the star.</p>"
 
 - name: "GNU Guix"
   logo: "guix.svg"
   logo_dark: "guix-dark.svg"
-  info: >
-    <ol class="distrotut">
-      <li>
-        <h2>Install Flatpak</h2>
-        <p>Flatpak can be installed from GNU Guix's default repositories. Run the following in a terminal:</p>
+  steps:
+    - name: "Install Flatpak"
+      text: '
+        <p>To install Flatpak on GNU Guix, run the following in a terminal:</p>
         <terminal-command>
           guix install flatpak
-        </terminal-command>
-      </li>
-      <li>
-        <h2>Add the Flathub repository</h2>
+        </terminal-command>'
+    - name: "Add the Flathub repository"
+      text: "
         <p>Flathub is the best place to get Flatpak apps. To enable it, run:</p>
         <terminal-command>
           flatpak --user remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
-        </terminal-command>
-      </li>
-      <li>
-        <h2>Restart</h2>
+        </terminal-command>"
+    - name: "Restart"
+      text: '
         <p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>
-        <p>Note: graphical installation of Flatpak apps may not be possible with GNU Guix.</p>
-      </li>
-    </ol>
+        <p>Note: graphical installation of Flatpak apps may not be possible with GNU Guix.</p>'

--- a/data/distro.yml
+++ b/data/distro.yml
@@ -20,7 +20,7 @@
       text: "
       <p>Flathub is the best place to get Flatpak apps. To enable it, run:</p>
       <terminal-command>
-      flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+        flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
       </terminal-command>"
     - name: 'Restart'
       text: '
@@ -71,14 +71,14 @@
       text: '
       <p>To install Flatpak, run the following in the terminal:</p>
       <terminal-command>
-      sudo apt install flatpak
+        sudo apt install flatpak
       </terminal-command>
       <p>A more up to date flatpak package is available in the <a href="https://backports.debian.org/Instructions/">Debian backports repository</a>. </p>'
     - name: Add the Flathub repository
       text: "
       <p>Flathub is the best place to get Flatpak apps. To enable it, run:</p>
       <terminal-command>
-      flatpak --user remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+        flatpak --user remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
       </terminal-command>"
     - name: Restart
       text: '
@@ -94,7 +94,7 @@
     <p>Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>
     <p>The above links should work on the default Red Hat Enterprise Linux Workstation 9 installation, but if they fail for some reason you can manually add the Flathub remote by running:</p>
     <terminal-command>
-    flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+      flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
     </terminal-command>
 
 - name: "Linux Mint"
@@ -116,7 +116,7 @@
       text: "
       <p>Flathub is the best place to get Flatpak apps. To enable it, run:</p>
       <terminal-command>
-      flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+        flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
       </terminal-command>"
     - name: 'Restart'
       text: '
@@ -150,7 +150,7 @@
       text: '
         <p>Flathub is the best place to get Flatpak apps. To enable it, download and install the <a class="btn btn-default" href="https://dl.flathub.org/repo/flathub.flatpakrepo">Flathub repository file</a> or run the following in a terminal:</p>
         <terminal-command>
-        flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+          flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
         </terminal-command>'
     - name: 'Restart'
       text: '
@@ -167,7 +167,7 @@
       text: '
         <p>Flathub is the best place to get Flatpak apps. To enable it, download and install the <a class="btn btn-default" href="https://dl.flathub.org/repo/flathub.flatpakrepo">Flathub repository file</a> or run the following in a terminal:</p>
         <terminal-command>
-        flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+          flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
         </terminal-command>'
     - name: 'Restart'
       text: '
@@ -204,7 +204,7 @@
       text: "
         <p>Flathub is the best place to get Flatpak apps. To enable it, run:</p>
         <terminal-command>
-        flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+          flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
         </terminal-command>"
     - name: 'Restart'
       text: '
@@ -220,25 +220,25 @@
       <terminal-command>sudo apt install flatpak</terminal-command>
       <p>With older Kubuntu versions, the official Flatpak PPA is the recommended way to install Flatpak. To install it, run the following in a terminal:</p>
       <terminal-command>
-      sudo add-apt-repository ppa:alexlarsson/flatpak\n
-      sudo apt update\n
-      sudo apt install flatpak\n
+        sudo add-apt-repository ppa:alexlarsson/flatpak\n
+        sudo apt update\n
+        sudo apt install flatpak\n
       </terminal-command>"
     - name: "Install the Discover Flatpak backend"
       text: "
       <p>The Flatpak plugin for the Software app makes it possible to install apps without needing the command line (available on Kubuntu 18.04 and newer). To install on 20.04 or later, run:</p>
       <terminal-command>
-      sudo apt install plasma-discover-backend-flatpak
+        sudo apt install plasma-discover-backend-flatpak
       </terminal-command>
       <p>On Kubuntu 18.04, you should run this instead:</p>
       <terminal-command>
-      sudo apt install plasma-discover-flatpak-backend
+        sudo apt install plasma-discover-flatpak-backend
       </terminal-command>"
     - name: "Add the Flathub repository"
       text: '
       <p>Flathub is the best place to get Flatpak apps. To enable it, download and install the <a class="btn btn-default" href="https://dl.flathub.org/repo/flathub.flatpakrepo">Flathub repository file</a> or run the following in a terminal:</p>
       <terminal-command>
-      flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+        flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
       </terminal-command>'
     - name: 'Restart'
       text: '
@@ -255,7 +255,7 @@
       text: '
       <p>Flathub is the best place to get Flatpak apps. To enable it, download and install the <a class="btn btn-default" href="https://dl.flathub.org/repo/flathub.flatpakrepo">Flathub repository file</a> or run the following in a terminal:</p>
       <terminal-command>
-      flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+        flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
       </terminal-command>'
     - name: 'Restart'
       text: '
@@ -279,7 +279,7 @@
       text: "
       <p>Flathub is the best place to get Flatpak apps. To enable it, download and install the <a class='btn btn-default' href='https://dl.flathub.org/repo/flathub.flatpakrepo'>Flathub repository file</a> or run the following in a terminal:</p>
       <terminal-command>
-      flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+        flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
       </terminal-command>"
     - name: 'Restart'
       text: '
@@ -298,7 +298,7 @@
       text: "
         <p>Flathub is the best place to get Flatpak apps. To enable it, download and install the <a class='btn btn-default' href='https://dl.flathub.org/repo/flathub.flatpakrepo'>Flathub repository file</a> or run the following in a terminal:</p>
         <terminal-command>
-        flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+          flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
         </terminal-command>"
     - name: 'Restart'
       text: '
@@ -318,7 +318,7 @@
     - name: "Add the Flathub repository"
       text: "<p>Flathub is the best place to get Flatpak apps. To enable it, download and install the <a class='btn btn-default' href='https://dl.flathub.org/repo/flathub.flatpakrepo'>Flathub repository file</a> or run the following in a terminal:</p>
       <terminal-command>
-      flatpak remote-add --user --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+        flatpak remote-add --user --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
       </terminal-command>"
     - name: 'Restart'
       text: '<p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>
@@ -340,13 +340,13 @@
       text: '
         <p>A flatpak package is available in Raspberry Pi OS (previously called Raspbian) Stretch and newer. To install it, run the following as root:</p>
         <terminal-command>
-        apt install flatpak
+          apt install flatpak
         </terminal-command>'
     - name: "Add the Flathub repository"
       text: "
         <p>Flathub is the best place to get Flatpak apps. To enable it, run:</p>
         <terminal-command>
-        flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+          flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
         </terminal-command>
         <p><b>Important note:</b> As of March 2021, Raspberry Pi computers still ship with the 32-bit version of Raspberry Pi OS. However Flathub started phasing out support for that architecture. If you consider Flathub as an important source of applications, it is recommended to use Raspberry Pi OS 64-bit as newer applications are more likely to be available for that platform.</p>"
     - name: 'Restart'
@@ -374,7 +374,7 @@
       text: '
         <p>Flathub is the best place to get Flatpak apps. To enable it, run:</p>
         <terminal-command>
-        flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+          flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
         </terminal-command>'
     - name: "Restart"
       text: '
@@ -387,18 +387,18 @@
       text: "
         <p>To install Flatpak, set NixOS option <code>services.flatpak.enable</code> to <code>true</code> by putting the following into your <code>/etc/nixos/configuration.nix</code>:</p>
         <terminal-command>
-        services.flatpak.enable = true;
+          services.flatpak.enable = true;
         </terminal-command>
         <p>Then, rebuild and switch to the new configuration with:</p>
         <terminal-command>
-        sudo nixos-rebuild switch
+          sudo nixos-rebuild switch
         </terminal-command>
         <p>For more details see the <a href='https://nixos.org/manual/nixos/stable/index.html#module-services-flatpak'>NixOS documentation</a>.</p>"
     - name: "Add the Flathub repository"
       text: '
         <p>Flathub is the best place to get Flatpak apps. To enable it, run:</p>
         <terminal-command>
-        flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+          flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
         </terminal-command>'
     - name: "Restart"
       text: '

--- a/data/distro.yml
+++ b/data/distro.yml
@@ -22,7 +22,7 @@
       <terminal-command>
         flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
       </terminal-command>"
-    - name: 'Restart'
+    - name: Restart
       text: '
       <p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>'
 
@@ -118,7 +118,7 @@
       <terminal-command>
         flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
       </terminal-command>"
-    - name: 'Restart'
+    - name: Restart
       text: '
       <p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>'
 
@@ -152,7 +152,7 @@
         <terminal-command>
           flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
         </terminal-command>'
-    - name: 'Restart'
+    - name: Restart
       text: '
         <p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>'
 
@@ -169,7 +169,7 @@
         <terminal-command>
           flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
         </terminal-command>'
-    - name: 'Restart'
+    - name: Restart
       text: '
         <p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>'
 
@@ -206,7 +206,7 @@
         <terminal-command>
           flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
         </terminal-command>"
-    - name: 'Restart'
+    - name: Restart
       text: '
         <p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>
         <p>Note: graphical installation of Flatpak apps may not be possible with Gentoo.</p>'
@@ -240,7 +240,7 @@
       <terminal-command>
         flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
       </terminal-command>'
-    - name: 'Restart'
+    - name: Restart
       text: '
       <p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>'
 
@@ -257,7 +257,7 @@
       <terminal-command>
         flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
       </terminal-command>'
-    - name: 'Restart'
+    - name: Restart
       text: '
       <p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>
       <p>Note: graphical installation of Flatpak apps is not yet possible with Solus, but will be available in the near future.</p>'
@@ -281,7 +281,7 @@
       <terminal-command>
         flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
       </terminal-command>"
-    - name: 'Restart'
+    - name: Restart
       text: '
       <p>To complete the setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>'
 
@@ -300,7 +300,7 @@
         <terminal-command>
           flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
         </terminal-command>"
-    - name: 'Restart'
+    - name: Restart
       text: '
         <p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>
         <p>Note: graphical installation of Flatpak apps may not be possible with Mageia.</p>'
@@ -320,7 +320,7 @@
       <terminal-command>
         flatpak remote-add --user --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
       </terminal-command>"
-    - name: 'Restart'
+    - name: Restart
       text: '<p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>
             <p>Note: graphical installation of Flatpak apps may not be possible with Pop!_OS 19.10 and earlier.</p>'
 
@@ -349,7 +349,7 @@
           flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
         </terminal-command>
         <p><b>Important note:</b> As of March 2021, Raspberry Pi computers still ship with the 32-bit version of Raspberry Pi OS. However Flathub started phasing out support for that architecture. If you consider Flathub as an important source of applications, it is recommended to use Raspberry Pi OS 64-bit as newer applications are more likely to be available for that platform.</p>"
-    - name: 'Restart'
+    - name: Restart
       text: '<p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>
       <p>Note: graphical installation of Flatpak apps may not be possible with Raspberry Pi OS.</p>'
 
@@ -560,7 +560,7 @@
   logo: "endeavouros.svg"
   logo_dark: "endeavouros-dark.svg"
   steps:
-    - name:  'Install Flatpak'
+    - name: Install Flatpak
       text: '
       <p>To install Flatpak on EndeavorOS, you must first make sure your installation is up to date, run the following in a terminal:</p>
       <terminal-command>
@@ -575,7 +575,7 @@
       <terminal-command>
         flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
       </terminal-command>"
-    - name: 'Restart'
+    - name: Restart
       text: '<p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>
       <p>Note: graphical installation of Flatpak apps may not be possible with EndeavourOS.</p>'
 

--- a/source/distro-template.html.haml
+++ b/source/distro-template.html.haml
@@ -7,12 +7,18 @@ description: #{locals[:name]} Quick Setup
   .container
     .row
       .col-lg-10.col-lg-offset-1
-        %h1.centered 
+        %h1.centered
           = locals[:name]
           Quick Setup
         %p.centered
           Follow these simple steps to start using Flatpak
-         
+
     .row.largegap
       .col-lg-12
-        = locals[:info]
+        %ol.distrotut
+          - if locals[:introduction]
+            = locals[:introduction]
+          - Array(locals[:steps]).each_with_index do |step, i|
+            %li
+              %h2= step[:name]
+              %p= step[:text]


### PR DESCRIPTION
This seems to work fine, but I haven't made an in depth comparison.

One thing I'm considering, is splitting up steps into `name` (of the step) and `text` for that step.

Closes #651 