### PR TITLE
fix flathub remote url in distro.yml

### DIFF
--- a/data/distro.yml
+++ b/data/distro.yml
@@ -19,7 +19,7 @@
     - name: Add the Flathub repository
       text: "
         <p>Flathub is the best place to get Flatpak apps. To enable it, run:</p>
-        <terminal-command>flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo</terminal-command>"
+        <terminal-command>flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo</terminal-command>"
     - name: Restart
       text: '
         <p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>'
@@ -31,7 +31,7 @@
     <p>Flatpak is installed by default on Fedora Workstation, Fedora Silverblue, and Fedora Kinoite. To get started, all you need to do is enable Flathub, which is the best way to get Flatpak apps. Just download and install the <a class="btn btn-default" href="https://dl.flathub.org/repo/flathub.flatpakrepo">Flathub repository file</a>.</p>
     <p>Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>
     <p>The above links should work on the default GNOME and KDE Fedora installations, but if they fail for some reason you can manually add the Flathub remote by running:</p>
-    <terminal-command>flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo</terminal-command>
+    <terminal-command>flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo</terminal-command>
 
 - name: Manjaro
   logo: "manjaro.svg"
@@ -71,7 +71,7 @@
     - name: Add the Flathub repository
       text: "
         <p>Flathub is the best place to get Flatpak apps. To enable it, run:</p>
-        <terminal-command>flatpak --user remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo</terminal-command>"
+        <terminal-command>flatpak --user remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo</terminal-command>"
     - name: Restart
       text: '
         <p>To complete setup, restart Linux. You can do this by right-clicking terminal, and then clicking "Shut down Linux". Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>'
@@ -85,7 +85,7 @@
     <terminal-command>sudo yum install flatpak</terminal-command>
     <p>Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>
     <p>The above links should work on the default Red Hat Enterprise Linux Workstation 9 installation, but if they fail for some reason you can manually add the Flathub remote by running:</p>
-    <terminal-command>flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo</terminal-command>
+    <terminal-command>flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo</terminal-command>
 
 - name: Linux Mint
   logo: "mint.svg"
@@ -105,7 +105,7 @@
     - name: Add the Flathub repository
       text: "
         <p>Flathub is the best place to get Flatpak apps. To enable it, run:</p>
-        <terminal-command>flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo</terminal-command>"
+        <terminal-command>flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo</terminal-command>"
     - name: Restart
       text: '
         <p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>'
@@ -137,7 +137,7 @@
     - name: Add the Flathub repository
       text: '
         <p>Flathub is the best place to get Flatpak apps. To enable it, download and install the <a class="btn btn-default" href="https://dl.flathub.org/repo/flathub.flatpakrepo">Flathub repository file</a> or run the following in a terminal:</p>
-        <terminal-command>flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo</terminal-command>'
+        <terminal-command>flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo</terminal-command>'
     - name: Restart
       text: '
         <p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>'
@@ -152,7 +152,7 @@
     - name: Add the Flathub repository
       text: '
         <p>Flathub is the best place to get Flatpak apps. To enable it, download and install the <a class="btn btn-default" href="https://dl.flathub.org/repo/flathub.flatpakrepo">Flathub repository file</a> or run the following in a terminal:</p>
-        <terminal-command>flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo</terminal-command>'
+        <terminal-command>flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo</terminal-command>'
     - name: Restart
       text: '
         <p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>'
@@ -187,7 +187,7 @@
     - name: Add the Flathub repository
       text: "
         <p>Flathub is the best place to get Flatpak apps. To enable it, run:</p>
-        <terminal-command>flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo</terminal-command>"
+        <terminal-command>flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo</terminal-command>"
     - name: Restart
       text: '
         <p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>
@@ -215,7 +215,7 @@
     - name: Add the Flathub repository
       text: '
         <p>Flathub is the best place to get Flatpak apps. To enable it, download and install the <a class="btn btn-default" href="https://dl.flathub.org/repo/flathub.flatpakrepo">Flathub repository file</a> or run the following in a terminal:</p>
-        <terminal-command>flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo</terminal-command>'
+        <terminal-command>flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo</terminal-command>'
     - name: Restart
       text: '
         <p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>'
@@ -230,7 +230,7 @@
     - name: Add the Flathub repository
       text: '
         <p>Flathub is the best place to get Flatpak apps. To enable it, download and install the <a class="btn btn-default" href="https://dl.flathub.org/repo/flathub.flatpakrepo">Flathub repository file</a> or run the following in a terminal:</p>
-        <terminal-command>flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo</terminal-command>'
+        <terminal-command>flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo</terminal-command>'
     - name: Restart
       text: '
         <p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>
@@ -252,7 +252,7 @@
     - name: Add the Flathub repository
       text: "
         <p>Flathub is the best place to get Flatpak apps. To enable it, download and install the <a class='btn btn-default' href='https://dl.flathub.org/repo/flathub.flatpakrepo'>Flathub repository file</a> or run the following in a terminal:</p>
-        <terminal-command>flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo</terminal-command>"
+        <terminal-command>flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo</terminal-command>"
     - name: Restart
       text: '
         <p>To complete the setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>'
@@ -269,7 +269,7 @@
     - name: Add the Flathub repository
       text: "
         <p>Flathub is the best place to get Flatpak apps. To enable it, download and install the <a class='btn btn-default' href='https://dl.flathub.org/repo/flathub.flatpakrepo'>Flathub repository file</a> or run the following in a terminal:</p>
-        <terminal-command>flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo</terminal-command>"
+        <terminal-command>flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo</terminal-command>"
     - name: Restart
       text: '
         <p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>
@@ -288,7 +288,7 @@
     - name: Add the Flathub repository
       text:
         "<p>Flathub is the best place to get Flatpak apps. To enable it, download and install the <a class='btn btn-default' href='https://dl.flathub.org/repo/flathub.flatpakrepo'>Flathub repository file</a> or run the following in a terminal:</p>
-        <terminal-command>flatpak remote-add --user --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo</terminal-command>"
+        <terminal-command>flatpak remote-add --user --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo</terminal-command>"
     - name: Restart
       text:
         '<p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>
@@ -313,7 +313,7 @@
     - name: Add the Flathub repository
       text: "
         <p>Flathub is the best place to get Flatpak apps. To enable it, run:</p>
-        <terminal-command>flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo</terminal-command>
+        <terminal-command>flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo</terminal-command>
         <p><b>Important note:</b> As of March 2021, Raspberry Pi computers still ship with the 32-bit version of Raspberry Pi OS. However Flathub started phasing out support for that architecture. If you consider Flathub as an important source of applications, it is recommended to use Raspberry Pi OS 64-bit as newer applications are more likely to be available for that platform.</p>"
     - name: Restart
       text:
@@ -338,7 +338,7 @@
     - name: Add the Flathub repository
       text: "
         <p>Flathub is the best place to get Flatpak apps. To enable it, run:</p>
-        <terminal-command>flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo</terminal-command>"
+        <terminal-command>flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo</terminal-command>"
     - name: Restart
       text: '
         <p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>'
@@ -356,7 +356,7 @@
     - name: Add the Flathub repository
       text: "
         <p>Flathub is the best place to get Flatpak apps. To enable it, run:</p>
-        <terminal-command>flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo</terminal-command>"
+        <terminal-command>flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo</terminal-command>"
     - name: Restart
       text: '
         <p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>'
@@ -392,7 +392,7 @@
     - name: Add the Flathub repository
       text: "
         <p>Flathub is the best place to get Flatpak apps. To enable it, run:</p>
-        <terminal-command>flatpak --user remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo</terminal-command>"
+        <terminal-command>flatpak --user remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo</terminal-command>"
     - name: Restart
       text: '
         <p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>
@@ -409,7 +409,7 @@
     - name: Add the Flathub repository
       text: "
         <p>Flathub is the best place to get Flatpak apps. To enable it, run:</p>
-        <terminal-command>flatpak --user remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo</terminal-command>"
+        <terminal-command>flatpak --user remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo</terminal-command>"
     - name: Restart
       text: '
         <p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>'
@@ -430,7 +430,7 @@
     - name: Add the Flathub repository
       text: "
         <p>Flathub is the best place to get Flatpak apps. To enable it, run:</p>
-        <terminal-command>flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo</terminal-command>"
+        <terminal-command>flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo</terminal-command>"
     - name: Install the Deepin themes
       text: '
         <p>To install light and dark themes, run:</p>
@@ -457,7 +457,7 @@
     - name: Add the Flathub repository
       text: "
         <p>Flathub is the best place to get Flatpak apps. To enable it, run:</p>
-        <terminal-command>flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo</terminal-command>"
+        <terminal-command>flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo</terminal-command>"
     - name: Restart
       text: '
         <p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>'
@@ -485,7 +485,7 @@
     - name: Add the Flathub repository
       text: "
         <p>Flathub is the best place to get Flatpak apps. To enable it, run:</p>
-        <terminal-command>flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo</terminal-command>"
+        <terminal-command>flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo</terminal-command>"
     - name: Restart
       text: '
         <p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>
@@ -504,7 +504,7 @@
     - name: Add the Flathub repository
       text:
         "<p>Flathub is the best place to get Flatpak apps. To enable it, run:</p>
-        <terminal-command>flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo</terminal-command>"
+        <terminal-command>flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo</terminal-command>"
     - name: Restart
       text:
         '<p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>
@@ -532,7 +532,7 @@
     - name: Add the Flathub repository
       text: "
         <p>Flathub is the best place to get Flatpak apps. To enable it, run:</p>
-        <terminal-command>flatpak --user remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo</terminal-command>"
+        <terminal-command>flatpak --user remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo</terminal-command>"
     - name: Restart
       text: '
         <p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install some apps</a>!</p>


### PR DESCRIPTION
Hello,

While following this documentation and running the command:

```
flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
```

I ended up with the error:

```
Warning: Could not update extra metadata for 'flathub': GPG verification enabled, but no summary found (check that the configured URL in remote config is correct)
```

And failed to install any application with it.

Reading this issue: https://github.com/flatpak/flatpak/issues/1967#issuecomment-413323832 turns out the `.dl` part of the url needs to be removed and it fixed my problems.

Kind regards,