### PR TITLE
data/distro.yml: Fix Gentoo install instructions

### DIFF
--- a/data/distro.yml
+++ b/data/distro.yml
@@ -203,10 +203,8 @@
   steps:
     - name: Install Flatpak
       text: "
-        <p>To install Flatpak, enable the ~amd64 keyword for sys-apps/flatpak, acct-user/flatpak and acct-group/flatpak:</p>
-        <terminal-command>echo -e 'sys-apps/flatpak ~amd64\\nacct-user/flatpak ~amd64\\nacct-group/flatpak ~amd64\\ndev-util/ostree ~amd64' >> /etc/portage/package.accept_keywords/flatpak</terminal-command>
-        <p>Then, install Flatpak:</p>
-        <terminal-command>emerge sys-apps/flatpak</terminal-command>"
+        <p>To install Flatpak on Gentoo, simply run:</p>
+        <terminal-command>emerge --ask --verbose --sys-apps/flatpak</terminal-command>"
     - name: Add the Flathub repository
       text: "
         <p>Flathub is the best place to get Flatpak apps. To enable it, run:</p>


### PR DESCRIPTION
Infomation was outdated	so fixed to match the current state of Gentoo's packaging.