### PR TITLE
Remove flathub forum link

### DIFF
--- a/source/about.html.haml
+++ b/source/about.html.haml
@@ -37,11 +37,6 @@ description: About Flatpak
         .right.toneddown GitHub
       .col-lg-4.col-xs-8
         =link_to "github.com/flatpak", "https://github.com/flatpak"
-    .row
-      .col-lg-2.col-xs-4.col-lg-offset-4
-        .right.toneddown Forum
-      .col-lg-4.col-xs-8
-        =link_to "discourse.flathub.org", "https://discourse.flathub.org/"
     .row.largegap
       .col-lg-8.col-lg-offset-2
         %p


### PR DESCRIPTION
The link is confusing, as it links users from flatpak to flathub and makes it seem like the projects are connected.