### PR TITLE
Fixes the permission issue of the flatpak command on Ubuntu

### DIFF
--- a/data/distro.yml
+++ b/data/distro.yml
@@ -13,7 +13,7 @@
     - name: Add the Flathub repository
       text: "
         <p>Flathub is the best place to get Flatpak apps. To enable it, run:</p>
-        <terminal-command>flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo</terminal-command>"
+        <terminal-command>sudo flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo</terminal-command>"
     - name: Restart
       text: '
         <p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install apps</a>!</p>'


### PR DESCRIPTION
- Fixes https://github.com/flatpak/flatpak/issues/6476 .
- Fixes the permission issue of the flatpak command on Ubuntu.
- I think the correct approach is to either require the user to execute either `sudo flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo` or `flatpak remote-add --if-not-exists --user flathub https://dl.flathub.org/repo/flathub.flatpakrepo`. It's unreasonable to show the user an incorrect command in the documentation.